### PR TITLE
Update 14-11-2021

### DIFF
--- a/scenes/MosaikHeer-Update-14-11-2021.scn
+++ b/scenes/MosaikHeer-Update-14-11-2021.scn
@@ -1,4 +1,4 @@
-#2.7# "MosaikHeer_v4" "" %000000000 1                                                                                                 
+#4.0# "14-11-2021_after" "" %000000000 1                                                                                       
 /config/chlink OFF ON ON OFF OFF OFF ON OFF OFF OFF OFF OFF ON OFF ON OFF
 /config/auxlink OFF OFF ON ON
 /config/fxlink ON ON ON ON
@@ -12,13 +12,15 @@
 /config/talk/A  +2.3 OFF ON %000000001111111111
 /config/talk/B -11.0 OFF ON %010000000000000000
 /config/osc -41.0 100.2 1k00 F1 PINK 18
+/config/userrout/out 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+/config/userrout/in 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+/config/routing REC
 /config/routing/IN A1-8 A9-16 A17-24 A25-32 AUX1-4
 /config/routing/AES50A OUT1-8 OUT9-16 OUT1-8 OUT1-8 OUT1-8 OUT1-8
 /config/routing/AES50B OUT9-16 OUT9-16 OUT9-16 OUT9-16 OUT9-16 OUT9-16
 /config/routing/CARD A1-8 A9-16 A17-24 A25-32
 /config/routing/OUT OUT1-4 AUX/CR OUT9-12 OUT13-16
 /config/routing/PLAY AN1-8 AN1-8 AN1-8 AN1-8 AUX1-4
-/config/routing REC
 /config/userctrl/A WH
 /config/userctrl/A/enc "X001" "X101" "X209" "X202"
 /config/userctrl/A/btn "O40" "O42" "X200" "O44" "P0051" "P0052" "P0053" "P0058"
@@ -30,6 +32,10 @@
 /config/userctrl/C/btn "-" "-" "-" "-" "-" "-" "-" "-"
 /config/tape 8.0 8.0 ON
 /config/amixenable OFF OFF
+/config/dp48 %0000 0 AESA
+/config/dp48/assign 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+/config/dp48/link 1 1 1 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+/config/dp48/grpname "" "" "" "" "" "" "" "" "" "" "" ""
 /ch/01/config "Kick" 1 RD 1
 /ch/01/delay OFF   0.3
 /ch/01/preamp -18.0 OFF ON 24  51
@@ -44,21 +50,21 @@
 /ch/01/eq/3 PEQ 1k55 -7.25 1.3
 /ch/01/eq/4 HShv 339.6 +0.00 2.0
 /ch/01/mix ON   -oo ON +0 ON  +2.3
-/ch/01/mix/01 ON   -oo +0 PRE
-/ch/01/mix/02 ON   -oo
-/ch/01/mix/03 ON   -oo +0 PRE
-/ch/01/mix/04 ON   -oo
-/ch/01/mix/05 ON   -oo +0 PRE
+/ch/01/mix/01 ON   0.0 +0 PRE 0
+/ch/01/mix/02 ON   0.0
+/ch/01/mix/03 ON  -6.0 +0 PRE 0
+/ch/01/mix/04 ON  -6.0
+/ch/01/mix/05 ON   -oo +0 PRE 0
 /ch/01/mix/06 ON   -oo
-/ch/01/mix/07 ON   -oo +0 PRE
+/ch/01/mix/07 ON   -oo +0 PRE 0
 /ch/01/mix/08 ON   -oo
-/ch/01/mix/09 ON   -oo +0 PRE
+/ch/01/mix/09 ON   -oo +0 PRE 0
 /ch/01/mix/10 ON   -oo
-/ch/01/mix/11 ON  +0.8 +0 POST
+/ch/01/mix/11 ON  +0.8 +0 POST 0
 /ch/01/mix/12 ON  +0.8
-/ch/01/mix/13 ON   -oo +0 POST
+/ch/01/mix/13 ON   0.0 +0 POST 0
 /ch/01/mix/14 ON   -oo
-/ch/01/mix/15 ON   -oo +0 POST
+/ch/01/mix/15 ON   -oo +0 POST 0
 /ch/01/mix/16 ON   -oo
 /ch/01/grp %00000001 %000000
 /ch/01/automix OFF -12.0
@@ -76,89 +82,89 @@
 /ch/02/eq/3 PEQ 285.8 -5.25 1.8
 /ch/02/eq/4 HCut 677.7 +0.00 2.0
 /ch/02/mix ON   -oo ON +0 ON  +2.3
-/ch/02/mix/01 ON   -oo +0 PRE
-/ch/02/mix/02 ON   -oo
-/ch/02/mix/03 ON   -oo +0 PRE
+/ch/02/mix/01 ON   0.0 +0 PRE 0
+/ch/02/mix/02 ON   0.0
+/ch/02/mix/03 ON   -oo +0 PRE 0
 /ch/02/mix/04 ON   -oo
-/ch/02/mix/05 ON   -oo +0 PRE
+/ch/02/mix/05 ON   -oo +0 PRE 0
 /ch/02/mix/06 ON   -oo
-/ch/02/mix/07 ON   -oo +0 PRE
+/ch/02/mix/07 ON   -oo +0 PRE 0
 /ch/02/mix/08 ON   -oo
-/ch/02/mix/09 ON   -oo +0 PRE
+/ch/02/mix/09 ON   -oo +0 PRE 0
 /ch/02/mix/10 ON   -oo
-/ch/02/mix/11 ON   -oo -52 POST
+/ch/02/mix/11 ON   -oo -52 POST 0
 /ch/02/mix/12 ON   -oo
-/ch/02/mix/13 ON   -oo +0 POST
-/ch/02/mix/14 ON  -4.5
-/ch/02/mix/15 ON   -oo +0 POST
+/ch/02/mix/13 ON   0.0 +0 POST 0
+/ch/02/mix/14 ON  -5.5
+/ch/02/mix/15 ON   -oo +0 POST 0
 /ch/02/mix/16 ON   -oo
 /ch/02/grp %00000001 %000000
 /ch/02/automix OFF -12.0
-/ch/03/config "e-drum L" 1 RD 3
+/ch/03/config "OH L" 1 RD 3
 /ch/03/delay OFF   0.3
-/ch/03/preamp -18.0 OFF ON 24  49
+/ch/03/preamp -18.0 OFF ON 24 279
 /ch/03/gate OFF GATE -80.0 60.0 1  502  983 0
 /ch/03/gate/filter OFF 3.0 990.9
-/ch/03/dyn ON COMP PEAK LOG -13.5 5.0 2 0.00 21 10.0  151 POST 0 100 OFF
+/ch/03/dyn ON COMP PEAK LOG 0.0 2.0 5 0.00 2 0.02  59 POST 0 100 OFF
 /ch/03/dyn/filter OFF 3.0 990.9
 /ch/03/insert OFF POST OFF
 /ch/03/eq ON
-/ch/03/eq/1 PEQ 64.7 +1.00 2.0
-/ch/03/eq/2 PEQ 257.6 -6.75 2.0
-/ch/03/eq/3 PEQ 3k09 -3.25 1.4
-/ch/03/eq/4 HShv 9k35 -2.25 2.0
-/ch/03/mix ON   -oo ON -100 ON   0.0
-/ch/03/mix/01 ON   -oo -100 PRE
-/ch/03/mix/02 ON   -oo
-/ch/03/mix/03 ON   -oo -100 PRE
+/ch/03/eq/1 PEQ 124.7 +0.00 2.0
+/ch/03/eq/2 PEQ 496.6 +0.00 2.0
+/ch/03/eq/3 PEQ 1k97 +0.00 2.0
+/ch/03/eq/4 HShv 10k02 +0.00 2.0
+/ch/03/mix ON   -oo ON +0 OFF   -oo
+/ch/03/mix/01 ON  -3.0 +100 PRE 0
+/ch/03/mix/02 ON  -3.0
+/ch/03/mix/03 ON   -oo -100 PRE 0
 /ch/03/mix/04 ON   -oo
-/ch/03/mix/05 ON   -oo -100 PRE
+/ch/03/mix/05 ON   -oo -100 PRE 0
 /ch/03/mix/06 ON   -oo
-/ch/03/mix/07 ON   -oo -100 PRE
+/ch/03/mix/07 ON   -oo -100 PRE 0
 /ch/03/mix/08 ON   -oo
-/ch/03/mix/09 ON   -oo -100 PRE
+/ch/03/mix/09 ON   -oo -100 PRE 0
 /ch/03/mix/10 ON   -oo
-/ch/03/mix/11 ON  +2.8 -100 POST
-/ch/03/mix/12 ON  +2.8
-/ch/03/mix/13 ON   -oo -100 POST
-/ch/03/mix/14 ON -30.0
-/ch/03/mix/15 ON   -oo -100 POST
+/ch/03/mix/11 ON  -3.0 -100 PRE 0
+/ch/03/mix/12 ON  -3.0
+/ch/03/mix/13 ON -16.5 -100 POST 0
+/ch/03/mix/14 ON   -oo
+/ch/03/mix/15 ON   -oo -100 POST 0
 /ch/03/mix/16 ON   -oo
 /ch/03/grp %00000001 %000000
 /ch/03/automix OFF -12.0
-/ch/04/config "e-drum R" 1 RD 4
+/ch/04/config "OH R" 1 RD 4
 /ch/04/delay OFF   0.3
-/ch/04/preamp -18.0 OFF ON 24  49
+/ch/04/preamp -18.0 OFF ON 24 279
 /ch/04/gate OFF GATE -80.0 60.0 1  502  983 0
 /ch/04/gate/filter OFF 3.0 990.9
-/ch/04/dyn ON COMP PEAK LOG -13.5 5.0 2 0.00 21 10.0  151 POST 0 100 OFF
+/ch/04/dyn ON COMP PEAK LOG 0.0 2.0 5 0.00 2 0.02  59 POST 0 100 OFF
 /ch/04/dyn/filter OFF 3.0 990.9
 /ch/04/insert OFF POST OFF
 /ch/04/eq ON
-/ch/04/eq/1 PEQ 64.7 +1.00 2.0
-/ch/04/eq/2 PEQ 257.6 -6.75 2.0
-/ch/04/eq/3 PEQ 3k09 -3.25 1.4
-/ch/04/eq/4 HShv 9k35 -2.25 2.0
-/ch/04/mix ON   -oo ON +100 ON   0.0
-/ch/04/mix/01 ON   -oo +100 PRE
-/ch/04/mix/02 ON   -oo
-/ch/04/mix/03 ON   -oo +100 PRE
+/ch/04/eq/1 PEQ 124.7 +0.00 2.0
+/ch/04/eq/2 PEQ 496.6 +0.00 2.0
+/ch/04/eq/3 PEQ 1k97 +0.00 2.0
+/ch/04/eq/4 HShv 10k02 +0.00 2.0
+/ch/04/mix ON   -oo ON +0 OFF   -oo
+/ch/04/mix/01 ON  -3.0 -100 PRE 0
+/ch/04/mix/02 ON  -3.0
+/ch/04/mix/03 ON   -oo +100 PRE 0
 /ch/04/mix/04 ON   -oo
-/ch/04/mix/05 ON   -oo +100 PRE
+/ch/04/mix/05 ON   -oo +100 PRE 0
 /ch/04/mix/06 ON   -oo
-/ch/04/mix/07 ON   -oo +100 PRE
+/ch/04/mix/07 ON   -oo +100 PRE 0
 /ch/04/mix/08 ON   -oo
-/ch/04/mix/09 ON   -oo +100 PRE
+/ch/04/mix/09 ON   -oo +100 PRE 0
 /ch/04/mix/10 ON   -oo
-/ch/04/mix/11 ON  +2.8 +100 POST
-/ch/04/mix/12 ON  +2.8
-/ch/04/mix/13 ON   -oo +100 POST
-/ch/04/mix/14 ON -30.0
-/ch/04/mix/15 ON   -oo +100 POST
+/ch/04/mix/11 ON  -3.0 +100 PRE 0
+/ch/04/mix/12 ON  -3.0
+/ch/04/mix/13 ON -16.5 -100 POST 0
+/ch/04/mix/14 ON   -oo
+/ch/04/mix/15 ON   -oo -100 POST 0
 /ch/04/mix/16 ON   -oo
 /ch/04/grp %00000001 %000000
 /ch/04/automix OFF -12.0
-/ch/05/config "OH R" 1 RD 5
+/ch/05/config "e-drum L" 1 RD 5
 /ch/05/delay OFF   0.3
 /ch/05/preamp -18.0 OFF ON 24 279
 /ch/05/gate OFF GATE -80.0 60.0 1  502  983 0
@@ -171,26 +177,26 @@
 /ch/05/eq/2 PEQ 496.6 +0.00 2.0
 /ch/05/eq/3 PEQ 1k97 +0.00 2.0
 /ch/05/eq/4 HShv 10k02 +0.00 2.0
-/ch/05/mix ON   -oo ON -100 OFF   -oo
-/ch/05/mix/01 ON   -oo -100 PRE
-/ch/05/mix/02 ON   -oo
-/ch/05/mix/03 ON   -oo -100 PRE
+/ch/05/mix ON   -oo ON +0 OFF   -oo
+/ch/05/mix/01 ON  -3.0 +100 PRE 1
+/ch/05/mix/02 ON  -3.0
+/ch/05/mix/03 ON   -oo +100 PRE 1
 /ch/05/mix/04 ON   -oo
-/ch/05/mix/05 ON   -oo -100 PRE
+/ch/05/mix/05 ON   -oo +100 PRE 1
 /ch/05/mix/06 ON   -oo
-/ch/05/mix/07 ON   -oo -100 PRE
+/ch/05/mix/07 ON   -oo +100 PRE 1
 /ch/05/mix/08 ON   -oo
-/ch/05/mix/09 ON   -oo -100 PRE
+/ch/05/mix/09 ON   -oo +100 PRE 1
 /ch/05/mix/10 ON   -oo
-/ch/05/mix/11 ON  -0.5 -100 POST
-/ch/05/mix/12 ON  -0.5
-/ch/05/mix/13 ON   -oo -100 POST
+/ch/05/mix/11 ON  -3.0 +100 PRE 1
+/ch/05/mix/12 ON  -3.0
+/ch/05/mix/13 ON -16.5 +100 POST 0
 /ch/05/mix/14 ON   -oo
-/ch/05/mix/15 ON   -oo -100 POST
+/ch/05/mix/15 ON   -oo +100 POST 0
 /ch/05/mix/16 ON   -oo
 /ch/05/grp %00000001 %000000
 /ch/05/automix OFF -12.0
-/ch/06/config "OH R" 1 RD 6
+/ch/06/config "e-drum R" 1 RD 6
 /ch/06/delay OFF   0.3
 /ch/06/preamp -18.0 OFF ON 24 279
 /ch/06/gate OFF GATE -80.0 60.0 1  502  983 0
@@ -203,22 +209,22 @@
 /ch/06/eq/2 PEQ 496.6 +0.00 2.0
 /ch/06/eq/3 PEQ 1k97 +0.00 2.0
 /ch/06/eq/4 HShv 10k02 +0.00 2.0
-/ch/06/mix ON   -oo ON +100 OFF   -oo
-/ch/06/mix/01 ON   -oo +100 PRE
-/ch/06/mix/02 ON   -oo
-/ch/06/mix/03 ON   -oo +100 PRE
+/ch/06/mix ON   -oo ON +0 OFF   -oo
+/ch/06/mix/01 ON  -3.0 +100 PRE 1
+/ch/06/mix/02 ON  -3.0
+/ch/06/mix/03 ON   -oo +100 PRE 1
 /ch/06/mix/04 ON   -oo
-/ch/06/mix/05 ON   -oo +100 PRE
+/ch/06/mix/05 ON   -oo +100 PRE 1
 /ch/06/mix/06 ON   -oo
-/ch/06/mix/07 ON   -oo +100 PRE
+/ch/06/mix/07 ON   -oo +100 PRE 1
 /ch/06/mix/08 ON   -oo
-/ch/06/mix/09 ON   -oo +100 PRE
+/ch/06/mix/09 ON   -oo +100 PRE 1
 /ch/06/mix/10 ON   -oo
-/ch/06/mix/11 ON  -0.5 +100 POST
-/ch/06/mix/12 ON  -0.5
-/ch/06/mix/13 ON   -oo +100 POST
+/ch/06/mix/11 ON  -3.0 +100 PRE 1
+/ch/06/mix/12 ON  -3.0
+/ch/06/mix/13 ON -16.5 +100 POST 0
 /ch/06/mix/14 ON   -oo
-/ch/06/mix/15 ON   -oo +100 POST
+/ch/06/mix/15 ON   -oo +100 POST 0
 /ch/06/mix/16 ON   -oo
 /ch/06/grp %00000001 %000000
 /ch/06/automix OFF -12.0
@@ -236,21 +242,21 @@
 /ch/07/eq/3 PEQ 1k97 +0.00 2.0
 /ch/07/eq/4 HShv 10k02 +0.00 2.0
 /ch/07/mix ON   -oo ON +0 ON   0.0
-/ch/07/mix/01 ON   -oo +0 PRE
-/ch/07/mix/02 ON   -oo
-/ch/07/mix/03 ON   -oo +0 PRE
+/ch/07/mix/01 ON  -6.0 +0 PRE 0
+/ch/07/mix/02 ON  -6.0
+/ch/07/mix/03 ON   -oo +0 PRE 0
 /ch/07/mix/04 ON   -oo
-/ch/07/mix/05 ON   -oo +0 PRE
+/ch/07/mix/05 ON   -oo +0 PRE 0
 /ch/07/mix/06 ON   -oo
-/ch/07/mix/07 ON   -oo +0 PRE
+/ch/07/mix/07 ON   -oo +0 PRE 0
 /ch/07/mix/08 ON   -oo
-/ch/07/mix/09 ON   -oo +0 PRE
+/ch/07/mix/09 ON   -oo +0 PRE 0
 /ch/07/mix/10 ON   -oo
-/ch/07/mix/11 ON  +3.5 -24 POST
+/ch/07/mix/11 ON  +3.5 -24 POST 0
 /ch/07/mix/12 ON  +3.5
-/ch/07/mix/13 ON   -oo +0 POST
+/ch/07/mix/13 ON  -0.3 +0 POST 0
 /ch/07/mix/14 ON   -oo
-/ch/07/mix/15 ON   -oo +0 POST
+/ch/07/mix/15 ON   -oo +0 POST 0
 /ch/07/mix/16 ON   -oo
 /ch/07/grp %00000001 %000000
 /ch/07/automix OFF -12.0
@@ -268,21 +274,21 @@
 /ch/08/eq/3 PEQ 1k44 -5.00 1.2
 /ch/08/eq/4 HCut 2k51 +0.00 2.0
 /ch/08/mix ON   -oo ON +0 ON   0.0
-/ch/08/mix/01 ON   -oo +0 PRE
-/ch/08/mix/02 ON   -oo
-/ch/08/mix/03 ON   -oo +0 PRE
+/ch/08/mix/01 ON  -6.0 +0 PRE 0
+/ch/08/mix/02 ON  -6.0
+/ch/08/mix/03 ON   -oo +0 PRE 0
 /ch/08/mix/04 ON   -oo
-/ch/08/mix/05 ON   -oo +0 PRE
+/ch/08/mix/05 ON   -oo +0 PRE 0
 /ch/08/mix/06 ON   -oo
-/ch/08/mix/07 ON   -oo +0 PRE
+/ch/08/mix/07 ON   -oo +0 PRE 0
 /ch/08/mix/08 ON   -oo
-/ch/08/mix/09 ON   -oo +0 PRE
+/ch/08/mix/09 ON   -oo +0 PRE 0
 /ch/08/mix/10 ON   -oo
-/ch/08/mix/11 ON  +4.0 +10 POST
+/ch/08/mix/11 ON  +4.0 +10 POST 0
 /ch/08/mix/12 ON  +4.0
-/ch/08/mix/13 ON   -oo +0 POST
+/ch/08/mix/13 ON  -0.3 +0 POST 0
 /ch/08/mix/14 ON   -oo
-/ch/08/mix/15 ON   -oo +0 POST
+/ch/08/mix/15 ON   -oo +0 POST 0
 /ch/08/mix/16 ON   -oo
 /ch/08/grp %00000001 %000000
 /ch/08/automix OFF -12.0
@@ -300,21 +306,21 @@
 /ch/09/eq/3 PEQ 1k97 +0.00 2.0
 /ch/09/eq/4 HShv 1k97 -6.25 2.0
 /ch/09/mix ON   -oo ON +0 ON   0.0
-/ch/09/mix/01 ON   -oo +0 PRE
-/ch/09/mix/02 ON   -oo
-/ch/09/mix/03 ON   -oo +0 PRE
+/ch/09/mix/01 ON  -6.0 +0 PRE 0
+/ch/09/mix/02 ON  -6.0
+/ch/09/mix/03 ON   -oo +0 PRE 0
 /ch/09/mix/04 ON   -oo
-/ch/09/mix/05 ON   -oo +0 PRE
+/ch/09/mix/05 ON   -oo +0 PRE 0
 /ch/09/mix/06 ON   -oo
-/ch/09/mix/07 ON   -oo +0 PRE
+/ch/09/mix/07 ON   -oo +0 PRE 0
 /ch/09/mix/08 ON   -oo
-/ch/09/mix/09 ON   -oo +0 PRE
+/ch/09/mix/09 ON   -oo +0 PRE 0
 /ch/09/mix/10 ON   -oo
-/ch/09/mix/11 ON  +6.0 +60 POST
+/ch/09/mix/11 ON  +6.0 +60 POST 0
 /ch/09/mix/12 ON  +6.0
-/ch/09/mix/13 ON   -oo +0 POST
+/ch/09/mix/13 ON   0.0 +0 POST 0
 /ch/09/mix/14 ON   -oo
-/ch/09/mix/15 ON   -oo +0 POST
+/ch/09/mix/15 ON   -oo +0 POST 0
 /ch/09/mix/16 ON   -oo
 /ch/09/grp %00000001 %000000
 /ch/09/automix OFF -12.0
@@ -332,21 +338,21 @@
 /ch/10/eq/3 PEQ 4k68 +2.25 0.9
 /ch/10/eq/4 HShv 10k02 +0.00 2.0
 /ch/10/mix ON  -5.2 OFF +0 OFF  -4.3
-/ch/10/mix/01 ON   -oo +0 PRE
+/ch/10/mix/01 ON   -oo +0 PRE 0
 /ch/10/mix/02 ON   -oo
-/ch/10/mix/03 ON   -oo +0 PRE
+/ch/10/mix/03 ON   -oo +0 PRE 0
 /ch/10/mix/04 ON   -oo
-/ch/10/mix/05 ON   -oo +0 PRE
+/ch/10/mix/05 ON   -oo +0 PRE 0
 /ch/10/mix/06 ON   -oo
-/ch/10/mix/07 ON   -oo +0 PRE
+/ch/10/mix/07 ON   -oo +0 PRE 0
 /ch/10/mix/08 ON   -oo
-/ch/10/mix/09 ON   -oo +0 PRE
+/ch/10/mix/09 ON   -oo +0 PRE 0
 /ch/10/mix/10 ON   -oo
-/ch/10/mix/11 ON  +7.5 -48 POST
+/ch/10/mix/11 ON  +7.5 -48 POST 0
 /ch/10/mix/12 ON  +7.5
-/ch/10/mix/13 ON   -oo +0 POST
+/ch/10/mix/13 ON   -oo +0 POST 0
 /ch/10/mix/14 ON   -oo
-/ch/10/mix/15 ON   -oo +0 POST
+/ch/10/mix/15 ON   -oo +0 POST 0
 /ch/10/mix/16 ON   -oo
 /ch/10/grp %00000001 %000000
 /ch/10/automix OFF  +0.0
@@ -364,27 +370,27 @@
 /ch/11/eq/3 PEQ 2k89 -6.50 3.5
 /ch/11/eq/4 HShv 10k02 +0.00 2.0
 /ch/11/mix ON   -oo ON +0 OFF  -3.5
-/ch/11/mix/01 ON   -oo +0 PRE
+/ch/11/mix/01 ON   -oo +0 PRE 0
 /ch/11/mix/02 ON   -oo
-/ch/11/mix/03 ON   -oo +0 PRE
+/ch/11/mix/03 ON   -oo +0 PRE 0
 /ch/11/mix/04 ON   -oo
-/ch/11/mix/05 ON   -oo +0 PRE
-/ch/11/mix/06 ON   -oo
-/ch/11/mix/07 ON   -oo +0 PRE
+/ch/11/mix/05 ON  -0.8 +0 PRE 0
+/ch/11/mix/06 ON  -0.8
+/ch/11/mix/07 ON   -oo +0 PRE 0
 /ch/11/mix/08 ON   -oo
-/ch/11/mix/09 ON   -oo +0 PRE
+/ch/11/mix/09 ON   -oo +0 PRE 0
 /ch/11/mix/10 ON   -oo
-/ch/11/mix/11 ON  -2.3 +0 POST
+/ch/11/mix/11 ON  -2.3 +0 POST 0
 /ch/11/mix/12 ON  -2.3
-/ch/11/mix/13 ON   -oo +0 POST
+/ch/11/mix/13 ON   -oo +0 POST 0
 /ch/11/mix/14 ON   0.0
-/ch/11/mix/15 ON   -oo +0 POST
+/ch/11/mix/15 ON   -oo +0 POST 0
 /ch/11/mix/16 ON   -oo
 /ch/11/grp %00000010 %000000
 /ch/11/automix OFF  +0.0
 /ch/12/config "E Git" 1 GN 12
 /ch/12/delay OFF   0.3
-/ch/12/preamp -18.0 OFF ON 24 233
+/ch/12/preamp -18.0 OFF ON 24 149
 /ch/12/gate OFF GATE -80.0 60.0 1  251  703 0
 /ch/12/gate/filter OFF 3.0 990.9
 /ch/12/dyn ON COMP PEAK LOG 0.0 2.5 4 0.00 10 10.0  151 POST 0 100 ON
@@ -396,21 +402,21 @@
 /ch/12/eq/3 PEQ 1k97 -5.25 1.3
 /ch/12/eq/4 HShv 5k20 -2.75 2.0
 /ch/12/mix ON   -oo ON +0 OFF  -3.8
-/ch/12/mix/01 ON   -oo +0 PRE
+/ch/12/mix/01 ON   -oo +0 PRE 0
 /ch/12/mix/02 ON   -oo
-/ch/12/mix/03 ON   -oo +0 PRE
+/ch/12/mix/03 ON   -oo +0 PRE 0
 /ch/12/mix/04 ON   -oo
-/ch/12/mix/05 ON   -oo +0 PRE
-/ch/12/mix/06 ON   -oo
-/ch/12/mix/07 ON   -oo +0 PRE
+/ch/12/mix/05 ON  -0.5 +0 PRE 0
+/ch/12/mix/06 ON  -0.5
+/ch/12/mix/07 ON   -oo +0 PRE 0
 /ch/12/mix/08 ON   -oo
-/ch/12/mix/09 ON   -oo +0 PRE
+/ch/12/mix/09 ON   -oo +0 PRE 0
 /ch/12/mix/10 ON   -oo
-/ch/12/mix/11 ON  -1.5 +0 POST
+/ch/12/mix/11 ON  -1.5 +0 POST 0
 /ch/12/mix/12 ON  -1.5
-/ch/12/mix/13 ON   -oo +0 POST
+/ch/12/mix/13 ON   -oo +0 POST 0
 /ch/12/mix/14 ON   -oo
-/ch/12/mix/15 ON   -oo +0 POST
+/ch/12/mix/15 ON   -oo +0 POST 0
 /ch/12/mix/16 ON   -oo
 /ch/12/grp %00000010 %000000
 /ch/12/automix OFF  +0.0
@@ -428,21 +434,21 @@
 /ch/13/eq/3 PEQ 3k68 +3.75 0.9
 /ch/13/eq/4 HShv 10k02 +0.00 2.0
 /ch/13/mix ON   -oo ON -100 OFF  -4.0
-/ch/13/mix/01 ON   -oo +0 PRE
+/ch/13/mix/01 ON   -oo +0 PRE 0
 /ch/13/mix/02 ON   -oo
-/ch/13/mix/03 ON   -oo +0 PRE
+/ch/13/mix/03 ON   -oo +0 PRE 0
 /ch/13/mix/04 ON   -oo
-/ch/13/mix/05 ON   -oo +0 PRE
+/ch/13/mix/05 ON   -oo +0 PRE 0
 /ch/13/mix/06 ON   -oo
-/ch/13/mix/07 ON   -oo +0 PRE
-/ch/13/mix/08 ON   -oo
-/ch/13/mix/09 ON   -oo +0 PRE
+/ch/13/mix/07 ON   0.0 +0 PRE 0
+/ch/13/mix/08 ON   0.0
+/ch/13/mix/09 ON   -oo +0 PRE 0
 /ch/13/mix/10 ON   -oo
-/ch/13/mix/11 ON  -0.3 -100 POST
+/ch/13/mix/11 ON  -0.3 -100 POST 0
 /ch/13/mix/12 ON  -0.3
-/ch/13/mix/13 ON   -oo +0 POST
+/ch/13/mix/13 ON   -oo +0 POST 0
 /ch/13/mix/14 ON   -oo
-/ch/13/mix/15 ON   -oo +0 POST
+/ch/13/mix/15 ON   -oo +0 POST 0
 /ch/13/mix/16 ON   -oo
 /ch/13/grp %00000010 %000000
 /ch/13/automix OFF  +0.0
@@ -460,27 +466,27 @@
 /ch/14/eq/3 PEQ 3k68 +3.75 0.9
 /ch/14/eq/4 HShv 10k02 +0.00 2.0
 /ch/14/mix ON   -oo ON +100 OFF  -4.0
-/ch/14/mix/01 ON   -oo +0 PRE
+/ch/14/mix/01 ON   -oo +0 PRE 0
 /ch/14/mix/02 ON   -oo
-/ch/14/mix/03 ON   -oo +0 PRE
+/ch/14/mix/03 ON   -oo +0 PRE 0
 /ch/14/mix/04 ON   -oo
-/ch/14/mix/05 ON   -oo +0 PRE
+/ch/14/mix/05 ON   -oo +0 PRE 0
 /ch/14/mix/06 ON   -oo
-/ch/14/mix/07 ON   -oo +0 PRE
-/ch/14/mix/08 ON   -oo
-/ch/14/mix/09 ON   -oo +0 PRE
+/ch/14/mix/07 ON   0.0 +0 PRE 0
+/ch/14/mix/08 ON   0.0
+/ch/14/mix/09 ON   -oo +0 PRE 0
 /ch/14/mix/10 ON   -oo
-/ch/14/mix/11 ON  -0.3 +100 POST
+/ch/14/mix/11 ON  -0.3 +100 POST 0
 /ch/14/mix/12 ON  -0.3
-/ch/14/mix/13 ON   -oo +0 POST
+/ch/14/mix/13 ON   -oo +0 POST 0
 /ch/14/mix/14 ON   -oo
-/ch/14/mix/15 ON   -oo +0 POST
+/ch/14/mix/15 ON   -oo +0 POST 0
 /ch/14/mix/16 ON   -oo
 /ch/14/grp %00000010 %000000
 /ch/14/automix OFF  +0.0
 /ch/15/config "Bass" 1 GN 15
 /ch/15/delay OFF   0.3
-/ch/15/preamp -18.0 OFF ON 24  87
+/ch/15/preamp -18.0 OFF ON 24  61
 /ch/15/gate OFF GATE -80.0 60.0 1  502  983 0
 /ch/15/gate/filter OFF 3.0 990.9
 /ch/15/dyn ON COMP PEAK LOG -16.0 4.0 3 2.00 25 0.02  18 POST 0 100 OFF
@@ -492,21 +498,21 @@
 /ch/15/eq/3 PEQ 590.2 -8.25 8.6
 /ch/15/eq/4 HShv 1k21 +0.00 2.0
 /ch/15/mix ON   -oo ON +0 ON  -1.5
-/ch/15/mix/01 ON   -oo +0 PRE
-/ch/15/mix/02 ON   -oo
-/ch/15/mix/03 ON   -oo +0 PRE
-/ch/15/mix/04 ON   -oo
-/ch/15/mix/05 ON   -oo +0 PRE
+/ch/15/mix/01 ON  -6.0 +0 PRE 0
+/ch/15/mix/02 ON  -6.0
+/ch/15/mix/03 ON   0.0 +0 PRE 0
+/ch/15/mix/04 ON   0.0
+/ch/15/mix/05 ON   -oo +0 PRE 0
 /ch/15/mix/06 ON   -oo
-/ch/15/mix/07 ON   -oo +0 PRE
+/ch/15/mix/07 ON   -oo +0 PRE 0
 /ch/15/mix/08 ON   -oo
-/ch/15/mix/09 ON   -oo +0 PRE
+/ch/15/mix/09 ON   -oo +0 PRE 0
 /ch/15/mix/10 ON   -oo
-/ch/15/mix/11 ON  -3.3 +0 POST
+/ch/15/mix/11 ON  -3.3 +0 POST 0
 /ch/15/mix/12 ON  -3.3
-/ch/15/mix/13 ON   -oo +0 POST
+/ch/15/mix/13 ON   -oo +0 POST 0
 /ch/15/mix/14 ON   -oo
-/ch/15/mix/15 ON   -oo +0 POST
+/ch/15/mix/15 ON   -oo +0 POST 0
 /ch/15/mix/16 ON   -oo
 /ch/15/grp %00000010 %000000
 /ch/15/automix OFF  +0.0
@@ -524,21 +530,21 @@
 /ch/16/eq/3 PEQ 1k97 +0.00 2.0
 /ch/16/eq/4 HShv 10k02 +0.00 2.0
 /ch/16/mix ON   -oo ON +0 OFF  -4.3
-/ch/16/mix/01 ON   -oo +0 PRE
+/ch/16/mix/01 ON   -oo +0 PRE 0
 /ch/16/mix/02 ON   -oo
-/ch/16/mix/03 ON   -oo +0 PRE
+/ch/16/mix/03 ON   -oo +0 PRE 0
 /ch/16/mix/04 ON   -oo
-/ch/16/mix/05 ON   -oo +0 PRE
+/ch/16/mix/05 ON   -oo +0 PRE 0
 /ch/16/mix/06 ON   -oo
-/ch/16/mix/07 ON   -oo +0 PRE
+/ch/16/mix/07 ON   -oo +0 PRE 0
 /ch/16/mix/08 ON   -oo
-/ch/16/mix/09 ON   -oo +0 PRE
+/ch/16/mix/09 ON   -oo +0 PRE 0
 /ch/16/mix/10 ON   -oo
-/ch/16/mix/11 ON  -2.3 +0 POST
+/ch/16/mix/11 ON  -2.3 +0 POST 0
 /ch/16/mix/12 ON  -2.3
-/ch/16/mix/13 ON   -oo +0 POST
+/ch/16/mix/13 ON   -oo +0 POST 0
 /ch/16/mix/14 ON   -oo
-/ch/16/mix/15 ON   -oo +0 POST
+/ch/16/mix/15 ON   -oo +0 POST 0
 /ch/16/mix/16 ON   -oo
 /ch/16/grp %00000010 %000000
 /ch/16/automix OFF  +0.0
@@ -556,22 +562,22 @@
 /ch/17/eq/3 PEQ 924.8 -4.25 2.5
 /ch/17/eq/4 HShv 7k34 +2.00 2.0
 /ch/17/mix ON   -oo ON +0 OFF   -oo
-/ch/17/mix/01 ON   -oo +0 PRE
+/ch/17/mix/01 ON   -oo +0 PRE 0
 /ch/17/mix/02 ON   -oo
-/ch/17/mix/03 ON   -oo +0 PRE
+/ch/17/mix/03 ON   -oo +0 PRE 0
 /ch/17/mix/04 ON   -oo
-/ch/17/mix/05 ON   -oo +0 PRE
+/ch/17/mix/05 ON   -oo +0 PRE 0
 /ch/17/mix/06 ON   -oo
-/ch/17/mix/07 ON   -oo +0 PRE
+/ch/17/mix/07 ON   -oo +0 PRE 0
 /ch/17/mix/08 ON   -oo
-/ch/17/mix/09 ON   -oo +0 PRE
+/ch/17/mix/09 ON   -oo +0 PRE 0
 /ch/17/mix/10 ON   -oo
-/ch/17/mix/11 ON  +0.5 +0 POST
+/ch/17/mix/11 ON  +0.5 +0 POST 0
 /ch/17/mix/12 ON  +0.5
-/ch/17/mix/13 ON   -oo +0 POST
+/ch/17/mix/13 ON   -oo +0 POST 0
 /ch/17/mix/14 ON   -oo
-/ch/17/mix/15 ON   0.0 +0 POST
-/ch/17/mix/16 ON -38.0
+/ch/17/mix/15 ON   0.0 +0 POST 0
+/ch/17/mix/16 ON -12.0
 /ch/17/grp %00000100 %000000
 /ch/17/automix OFF  +0.0
 /ch/18/config "Voc 2" 1 WH 18
@@ -588,22 +594,22 @@
 /ch/18/eq/3 PEQ 2k19 +2.50 0.8
 /ch/18/eq/4 HShv 6k85 +2.75 2.0
 /ch/18/mix ON   -oo ON +0 OFF   -oo
-/ch/18/mix/01 ON   -oo +0 PRE
+/ch/18/mix/01 ON   -oo +0 PRE 0
 /ch/18/mix/02 ON   -oo
-/ch/18/mix/03 ON   -oo +0 PRE
+/ch/18/mix/03 ON   -oo +0 PRE 0
 /ch/18/mix/04 ON   -oo
-/ch/18/mix/05 ON   -oo +0 PRE
+/ch/18/mix/05 ON   -oo +0 PRE 0
 /ch/18/mix/06 ON   -oo
-/ch/18/mix/07 ON   -oo +0 PRE
+/ch/18/mix/07 ON   -oo +0 PRE 0
 /ch/18/mix/08 ON   -oo
-/ch/18/mix/09 ON   -oo +0 PRE
+/ch/18/mix/09 ON   -oo +0 PRE 0
 /ch/18/mix/10 ON   -oo
-/ch/18/mix/11 ON  -0.3 +0 POST
+/ch/18/mix/11 ON  -0.3 +0 POST 0
 /ch/18/mix/12 ON  -0.3
-/ch/18/mix/13 ON   -oo +0 POST
+/ch/18/mix/13 ON   -oo +0 POST 0
 /ch/18/mix/14 ON   -oo
-/ch/18/mix/15 ON   0.0 +0 POST
-/ch/18/mix/16 ON -38.0
+/ch/18/mix/15 ON   0.0 +0 POST 0
+/ch/18/mix/16 ON -12.0
 /ch/18/grp %00000100 %000000
 /ch/18/automix OFF  +0.0
 /ch/19/config "Voc 3" 1 WH 19
@@ -620,21 +626,21 @@
 /ch/19/eq/3 PEQ 1k91 +2.50 2.0
 /ch/19/eq/4 HShv 6k18 +2.25 2.0
 /ch/19/mix ON   -oo ON +0 OFF   -oo
-/ch/19/mix/01 ON   -oo +0 PRE
+/ch/19/mix/01 ON   -oo +0 PRE 0
 /ch/19/mix/02 ON   -oo
-/ch/19/mix/03 ON   -oo +0 PRE
+/ch/19/mix/03 ON   -oo +0 PRE 0
 /ch/19/mix/04 ON   -oo
-/ch/19/mix/05 ON   -oo +0 PRE
+/ch/19/mix/05 ON   -oo +0 PRE 0
 /ch/19/mix/06 ON   -oo
-/ch/19/mix/07 ON   -oo +0 PRE
+/ch/19/mix/07 ON   -oo +0 PRE 0
 /ch/19/mix/08 ON   -oo
-/ch/19/mix/09 ON   -oo +0 PRE
+/ch/19/mix/09 ON   -oo +0 PRE 0
 /ch/19/mix/10 ON   -oo
-/ch/19/mix/11 ON  -1.5 +0 POST
+/ch/19/mix/11 ON  -1.5 +0 POST 0
 /ch/19/mix/12 ON  -1.5
-/ch/19/mix/13 ON   -oo +0 POST
+/ch/19/mix/13 ON   -oo +0 POST 0
 /ch/19/mix/14 ON   -oo
-/ch/19/mix/15 ON   0.0 +0 POST
+/ch/19/mix/15 ON   0.0 +0 POST 0
 /ch/19/mix/16 ON   -oo
 /ch/19/grp %00000100 %000000
 /ch/19/automix OFF  +0.0
@@ -652,21 +658,21 @@
 /ch/20/eq/3 PEQ 1k97 +0.00 2.0
 /ch/20/eq/4 HShv 10k02 +0.00 2.0
 /ch/20/mix ON   -oo OFF +0 OFF   -oo
-/ch/20/mix/01 ON   -oo +0 PRE
+/ch/20/mix/01 ON   -oo +0 PRE 0
 /ch/20/mix/02 ON   -oo
-/ch/20/mix/03 ON   -oo +0 PRE
+/ch/20/mix/03 ON   -oo +0 PRE 0
 /ch/20/mix/04 ON   -oo
-/ch/20/mix/05 ON   -oo +0 PRE
+/ch/20/mix/05 ON   -oo +0 PRE 0
 /ch/20/mix/06 ON   -oo
-/ch/20/mix/07 ON   -oo +0 PRE
+/ch/20/mix/07 ON   -oo +0 PRE 0
 /ch/20/mix/08 ON   -oo
-/ch/20/mix/09 ON   -oo +0 PRE
+/ch/20/mix/09 ON   -oo +0 PRE 0
 /ch/20/mix/10 ON   -oo
-/ch/20/mix/11 ON  -0.5 +0 POST
+/ch/20/mix/11 ON  -0.5 +0 POST 0
 /ch/20/mix/12 ON  -0.5
-/ch/20/mix/13 ON   -oo +0 POST
+/ch/20/mix/13 ON   -oo +0 POST 0
 /ch/20/mix/14 ON   -oo
-/ch/20/mix/15 ON   -oo +0 POST
+/ch/20/mix/15 ON   0.0 +0 POST 0
 /ch/20/mix/16 ON   -oo
 /ch/20/grp %00000100 %000000
 /ch/20/automix OFF  +0.0
@@ -684,27 +690,27 @@
 /ch/21/eq/3 PEQ 2k27 +0.00 2.0
 /ch/21/eq/4 HCut 7k60 -1.50 2.0
 /ch/21/mix ON   -oo OFF +0 OFF   -oo
-/ch/21/mix/01 ON   -oo +0 PRE
-/ch/21/mix/02 ON   -oo
-/ch/21/mix/03 ON   -oo +0 PRE
-/ch/21/mix/04 ON   -oo
-/ch/21/mix/05 ON   -oo +0 PRE
-/ch/21/mix/06 ON   -oo
-/ch/21/mix/07 ON   -oo +0 PRE
-/ch/21/mix/08 ON   -oo
-/ch/21/mix/09 ON   -oo +0 PRE
-/ch/21/mix/10 ON   -oo
-/ch/21/mix/11 OFF   -oo +0 POST
+/ch/21/mix/01 ON  -3.0 +0 PRE 0
+/ch/21/mix/02 ON  -3.0
+/ch/21/mix/03 ON -12.0 +0 PRE 0
+/ch/21/mix/04 ON -12.0
+/ch/21/mix/05 ON -12.0 +0 PRE 0
+/ch/21/mix/06 ON -12.0
+/ch/21/mix/07 ON -12.0 +0 PRE 0
+/ch/21/mix/08 ON -12.0
+/ch/21/mix/09 ON -12.0 +0 PRE 0
+/ch/21/mix/10 ON -12.0
+/ch/21/mix/11 OFF   -oo +0 POST 0
 /ch/21/mix/12 OFF   -oo
-/ch/21/mix/13 OFF   -oo +0 POST
+/ch/21/mix/13 OFF   -oo +0 POST 0
 /ch/21/mix/14 OFF   -oo
-/ch/21/mix/15 OFF   -oo +0 POST
+/ch/21/mix/15 OFF   -oo +0 POST 0
 /ch/21/mix/16 OFF   -oo
 /ch/21/grp %00000000 %000000
 /ch/21/automix OFF  +0.0
 /ch/22/config "Music Direct" 1 WHi 22
 /ch/22/delay OFF   0.3
-/ch/22/preamp -18.0 OFF ON 24 168
+/ch/22/preamp -18.0 OFF ON 24 220
 /ch/22/gate OFF GATE -80.0 60.0 1  502  983 0
 /ch/22/gate/filter OFF 3.0 990.9
 /ch/22/dyn OFF COMP RMS LOG -57.5 7.0 4 3.00 12 0.02  42 POST 0 100 ON
@@ -714,29 +720,29 @@
 /ch/22/eq/1 PEQ 124.7 +0.00 2.0
 /ch/22/eq/2 PEQ 924.8 -2.25 1.3
 /ch/22/eq/3 PEQ 1k97 +0.00 2.0
-/ch/22/eq/4 PEQ 5k76 +2.00 0.7
+/ch/22/eq/4 HCut 2k79 +3.00 0.7
 /ch/22/mix ON   -oo OFF +0 OFF   -oo
-/ch/22/mix/01 ON   -oo +0 PRE
-/ch/22/mix/02 ON   -oo
-/ch/22/mix/03 ON   -oo +0 PRE
-/ch/22/mix/04 ON   -oo
-/ch/22/mix/05 ON   -oo +0 PRE
-/ch/22/mix/06 ON   -oo
-/ch/22/mix/07 ON   -oo +0 PRE
-/ch/22/mix/08 ON   -oo
-/ch/22/mix/09 ON   -oo +0 PRE
-/ch/22/mix/10 ON   -oo
-/ch/22/mix/11 OFF   -oo +0 POST
+/ch/22/mix/01 ON  -9.0 +0 PRE 0
+/ch/22/mix/02 ON  -9.0
+/ch/22/mix/03 ON  -9.0 +0 PRE 0
+/ch/22/mix/04 ON  -9.0
+/ch/22/mix/05 ON  -9.0 +0 PRE 0
+/ch/22/mix/06 ON  -9.0
+/ch/22/mix/07 ON  -9.0 +0 PRE 0
+/ch/22/mix/08 ON  -9.0
+/ch/22/mix/09 ON  -9.0 +0 PRE 0
+/ch/22/mix/10 ON  -9.0
+/ch/22/mix/11 OFF   -oo +0 POST 0
 /ch/22/mix/12 OFF   -oo
-/ch/22/mix/13 ON   -oo +0 POST
+/ch/22/mix/13 OFF   -oo +0 POST 0
 /ch/22/mix/14 OFF   -oo
-/ch/22/mix/15 OFF   -oo +0 POST
+/ch/22/mix/15 OFF   -oo +0 POST 0
 /ch/22/mix/16 OFF   -oo
 /ch/22/grp %00000000 %000000
 /ch/22/automix OFF  +0.0
 /ch/23/config "Worship Lead" 1 WHi 23
 /ch/23/delay OFF   0.3
-/ch/23/preamp -18.0 OFF ON 24 168
+/ch/23/preamp -18.0 OFF ON 24 220
 /ch/23/gate OFF GATE -80.0 60.0 1  502  983 0
 /ch/23/gate/filter OFF 3.0 990.9
 /ch/23/dyn OFF COMP PEAK LOG -34.5 3.0 2 0.00 12 0.02  42 POST 0 100 OFF
@@ -746,23 +752,23 @@
 /ch/23/eq/1 PEQ 124.7 +0.00 2.0
 /ch/23/eq/2 PEQ 496.6 +0.00 2.0
 /ch/23/eq/3 PEQ 1k97 +0.00 2.0
-/ch/23/eq/4 HShv 10k02 +0.00 2.0
+/ch/23/eq/4 HCut 3k09 +6.00 2.0
 /ch/23/mix ON   -oo OFF +0 OFF   -oo
-/ch/23/mix/01 ON   -oo +0 PRE
-/ch/23/mix/02 ON   -oo
-/ch/23/mix/03 ON   -oo +0 PRE
-/ch/23/mix/04 ON   -oo
-/ch/23/mix/05 ON   -oo +0 PRE
-/ch/23/mix/06 ON   -oo
-/ch/23/mix/07 ON   -oo +0 PRE
-/ch/23/mix/08 ON   -oo
-/ch/23/mix/09 ON   -oo +0 PRE
-/ch/23/mix/10 ON   -oo
-/ch/23/mix/11 OFF   -oo +0 POST
+/ch/23/mix/01 ON  -9.0 +0 PRE 0
+/ch/23/mix/02 ON  -9.0
+/ch/23/mix/03 ON  -9.0 +0 PRE 0
+/ch/23/mix/04 ON  -9.0
+/ch/23/mix/05 ON  -9.0 +0 PRE 0
+/ch/23/mix/06 ON  -9.0
+/ch/23/mix/07 ON  -9.0 +0 PRE 0
+/ch/23/mix/08 ON  -9.0
+/ch/23/mix/09 ON  -9.0 +0 PRE 0
+/ch/23/mix/10 ON  -9.0
+/ch/23/mix/11 OFF   -oo +0 POST 0
 /ch/23/mix/12 OFF   -oo
-/ch/23/mix/13 ON   -oo +0 POST
+/ch/23/mix/13 OFF   -oo +0 POST 0
 /ch/23/mix/14 OFF   -oo
-/ch/23/mix/15 OFF   -oo +0 POST
+/ch/23/mix/15 OFF   -oo +0 POST 0
 /ch/23/mix/16 OFF   -oo
 /ch/23/grp %00000000 %000000
 /ch/23/automix OFF  +0.0
@@ -780,21 +786,21 @@
 /ch/24/eq/3 PEQ 1k97 +0.00 2.0
 /ch/24/eq/4 HShv 10k02 +0.00 2.0
 /ch/24/mix ON   -oo OFF +0 OFF   -oo
-/ch/24/mix/01 ON   -oo +0 PRE
+/ch/24/mix/01 ON   -oo +0 PRE 0
 /ch/24/mix/02 ON   -oo
-/ch/24/mix/03 ON   -oo +0 PRE
+/ch/24/mix/03 ON   -oo +0 PRE 0
 /ch/24/mix/04 ON   -oo
-/ch/24/mix/05 ON   -oo +0 PRE
+/ch/24/mix/05 ON   -oo +0 PRE 0
 /ch/24/mix/06 ON   -oo
-/ch/24/mix/07 ON   -oo +0 PRE
+/ch/24/mix/07 ON   -oo +0 PRE 0
 /ch/24/mix/08 ON   -oo
-/ch/24/mix/09 ON   -oo +0 PRE
+/ch/24/mix/09 ON   -oo +0 PRE 0
 /ch/24/mix/10 ON   -oo
-/ch/24/mix/11 OFF   -oo +0 POST
+/ch/24/mix/11 OFF   -oo +0 POST 0
 /ch/24/mix/12 OFF   -oo
-/ch/24/mix/13 ON   -oo +0 POST
+/ch/24/mix/13 ON   -oo +0 POST 0
 /ch/24/mix/14 OFF   -oo
-/ch/24/mix/15 OFF   -oo +0 POST
+/ch/24/mix/15 OFF   -oo +0 POST 0
 /ch/24/mix/16 OFF   -oo
 /ch/24/grp %00000000 %000000
 /ch/24/automix OFF  +0.0
@@ -812,21 +818,21 @@
 /ch/25/eq/3 PEQ 1k97 +0.00 2.0
 /ch/25/eq/4 HShv 10k02 +0.00 2.0
 /ch/25/mix ON   0.0 ON -100 ON  -8.0
-/ch/25/mix/01 ON   -oo -100 PRE
+/ch/25/mix/01 ON   -oo -100 POST 0
 /ch/25/mix/02 ON   -oo
-/ch/25/mix/03 ON   -oo -100 PRE
+/ch/25/mix/03 ON   -oo -100 POST 0
 /ch/25/mix/04 ON   -oo
-/ch/25/mix/05 ON   -oo -100 PRE
+/ch/25/mix/05 ON   -oo -100 POST 0
 /ch/25/mix/06 ON   -oo
-/ch/25/mix/07 ON   -oo -100 PRE
+/ch/25/mix/07 ON   -oo -100 POST 0
 /ch/25/mix/08 ON   -oo
-/ch/25/mix/09 ON   -oo -100 PRE
+/ch/25/mix/09 ON   -oo -100 POST 0
 /ch/25/mix/10 ON   -oo
-/ch/25/mix/11 ON  -3.3 -100 POST
+/ch/25/mix/11 ON  -3.3 -100 POST 0
 /ch/25/mix/12 ON  -3.3
-/ch/25/mix/13 ON   -oo +0 POST
+/ch/25/mix/13 ON   -oo +0 POST 0
 /ch/25/mix/14 OFF   -oo
-/ch/25/mix/15 OFF   -oo +0 POST
+/ch/25/mix/15 OFF   -oo +0 POST 0
 /ch/25/mix/16 OFF   -oo
 /ch/25/grp %00010000 %000000
 /ch/25/automix OFF  +0.0
@@ -844,21 +850,21 @@
 /ch/26/eq/3 PEQ 1k97 +0.00 2.0
 /ch/26/eq/4 HShv 10k02 +0.00 2.0
 /ch/26/mix ON   0.0 ON +100 ON  -8.0
-/ch/26/mix/01 ON   -oo +100 PRE
+/ch/26/mix/01 ON   -oo +100 POST 0
 /ch/26/mix/02 ON   -oo
-/ch/26/mix/03 ON   -oo +100 PRE
+/ch/26/mix/03 ON   -oo +100 POST 0
 /ch/26/mix/04 ON   -oo
-/ch/26/mix/05 ON   -oo +100 PRE
+/ch/26/mix/05 ON   -oo +100 POST 0
 /ch/26/mix/06 ON   -oo
-/ch/26/mix/07 ON   -oo +100 PRE
+/ch/26/mix/07 ON   -oo +100 POST 0
 /ch/26/mix/08 ON   -oo
-/ch/26/mix/09 ON   -oo +100 PRE
+/ch/26/mix/09 ON   -oo +100 POST 0
 /ch/26/mix/10 ON   -oo
-/ch/26/mix/11 ON  -3.3 +100 POST
+/ch/26/mix/11 ON  -3.3 +100 POST 0
 /ch/26/mix/12 ON  -3.3
-/ch/26/mix/13 ON   -oo +0 POST
+/ch/26/mix/13 ON   -oo +0 POST 0
 /ch/26/mix/14 OFF   -oo
-/ch/26/mix/15 OFF   -oo +0 POST
+/ch/26/mix/15 OFF   -oo +0 POST 0
 /ch/26/mix/16 OFF   -oo
 /ch/26/grp %00010000 %000000
 /ch/26/automix OFF  +0.0
@@ -876,21 +882,21 @@
 /ch/27/eq/3 PEQ 1k97 +0.00 2.0
 /ch/27/eq/4 HShv 10k02 +0.00 2.0
 /ch/27/mix ON   -oo OFF +0 OFF   -oo
-/ch/27/mix/01 ON   -oo +0 PRE
+/ch/27/mix/01 ON   -oo +0 PRE 0
 /ch/27/mix/02 ON   -oo
-/ch/27/mix/03 ON   -oo +0 PRE
+/ch/27/mix/03 ON   -oo +0 PRE 0
 /ch/27/mix/04 ON   -oo
-/ch/27/mix/05 ON   -oo +0 PRE
+/ch/27/mix/05 ON   -oo +0 PRE 0
 /ch/27/mix/06 ON   -oo
-/ch/27/mix/07 ON   -oo +0 PRE
+/ch/27/mix/07 ON   -oo +0 PRE 0
 /ch/27/mix/08 ON   -oo
-/ch/27/mix/09 ON   -oo +0 PRE
+/ch/27/mix/09 ON   -oo +0 PRE 0
 /ch/27/mix/10 ON   -oo
-/ch/27/mix/11 OFF   -oo +0 POST
+/ch/27/mix/11 OFF   -oo +0 POST 0
 /ch/27/mix/12 OFF   -oo
-/ch/27/mix/13 ON   -oo +0 POST
+/ch/27/mix/13 ON   -oo +0 POST 0
 /ch/27/mix/14 OFF   -oo
-/ch/27/mix/15 OFF   -oo +0 POST
+/ch/27/mix/15 OFF   -oo +0 POST 0
 /ch/27/mix/16 OFF   -oo
 /ch/27/grp %00000000 %000000
 /ch/27/automix OFF  +0.0
@@ -908,21 +914,21 @@
 /ch/28/eq/3 PEQ 1k97 +0.00 2.0
 /ch/28/eq/4 HShv 10k02 +0.00 2.0
 /ch/28/mix ON   -oo OFF +0 OFF   -oo
-/ch/28/mix/01 ON   -oo +0 PRE
+/ch/28/mix/01 ON   -oo +0 PRE 0
 /ch/28/mix/02 ON   -oo
-/ch/28/mix/03 ON   -oo +0 PRE
+/ch/28/mix/03 ON   -oo +0 PRE 0
 /ch/28/mix/04 ON   -oo
-/ch/28/mix/05 ON   -oo +0 PRE
+/ch/28/mix/05 ON   -oo +0 PRE 0
 /ch/28/mix/06 ON   -oo
-/ch/28/mix/07 ON   -oo +0 PRE
+/ch/28/mix/07 ON   -oo +0 PRE 0
 /ch/28/mix/08 ON   -oo
-/ch/28/mix/09 ON   -oo +0 PRE
+/ch/28/mix/09 ON   -oo +0 PRE 0
 /ch/28/mix/10 ON   -oo
-/ch/28/mix/11 OFF   -oo +0 POST
+/ch/28/mix/11 OFF   -oo +0 POST 0
 /ch/28/mix/12 OFF   -oo
-/ch/28/mix/13 ON   -oo +0 POST
+/ch/28/mix/13 ON   -oo +0 POST 0
 /ch/28/mix/14 OFF   -oo
-/ch/28/mix/15 OFF   -oo +0 POST
+/ch/28/mix/15 OFF   -oo +0 POST 0
 /ch/28/mix/16 OFF   -oo
 /ch/28/grp %00000000 %000000
 /ch/28/automix OFF  +0.0
@@ -940,21 +946,21 @@
 /ch/29/eq/3 PEQ 1k97 +0.00 2.0
 /ch/29/eq/4 HShv 10k02 +0.00 2.0
 /ch/29/mix ON   -oo OFF -100 OFF   -oo
-/ch/29/mix/01 ON   -oo -100 PRE
+/ch/29/mix/01 ON   -oo -100 PRE 0
 /ch/29/mix/02 ON   -oo
-/ch/29/mix/03 ON   -oo -100 PRE
+/ch/29/mix/03 ON   -oo -100 PRE 0
 /ch/29/mix/04 ON   -oo
-/ch/29/mix/05 ON   -oo -100 PRE
+/ch/29/mix/05 ON   -oo -100 PRE 0
 /ch/29/mix/06 ON   -oo
-/ch/29/mix/07 ON   -oo -100 PRE
+/ch/29/mix/07 ON   -oo -100 PRE 0
 /ch/29/mix/08 ON   -oo
-/ch/29/mix/09 ON   -oo -100 PRE
+/ch/29/mix/09 ON   -oo -100 PRE 0
 /ch/29/mix/10 ON   -oo
-/ch/29/mix/11 ON  -1.5 -100 POST
+/ch/29/mix/11 ON  -1.5 -100 POST 0
 /ch/29/mix/12 ON  -1.5
-/ch/29/mix/13 ON   -oo -100 POST
+/ch/29/mix/13 ON   -oo -100 POST 0
 /ch/29/mix/14 ON   -oo
-/ch/29/mix/15 ON   -oo -100 POST
+/ch/29/mix/15 ON   -oo -100 POST 0
 /ch/29/mix/16 ON   -oo
 /ch/29/grp %01000000 %000000
 /ch/29/automix OFF  +0.0
@@ -972,21 +978,21 @@
 /ch/30/eq/3 PEQ 1k97 +0.00 2.0
 /ch/30/eq/4 HShv 10k02 +0.00 2.0
 /ch/30/mix ON   -oo OFF +100 OFF   -oo
-/ch/30/mix/01 ON   -oo +100 PRE
+/ch/30/mix/01 ON   -oo +100 PRE 0
 /ch/30/mix/02 ON   -oo
-/ch/30/mix/03 ON   -oo +100 PRE
+/ch/30/mix/03 ON   -oo +100 PRE 0
 /ch/30/mix/04 ON   -oo
-/ch/30/mix/05 ON   -oo +100 PRE
+/ch/30/mix/05 ON   -oo +100 PRE 0
 /ch/30/mix/06 ON   -oo
-/ch/30/mix/07 ON   -oo +100 PRE
+/ch/30/mix/07 ON   -oo +100 PRE 0
 /ch/30/mix/08 ON   -oo
-/ch/30/mix/09 ON   -oo +100 PRE
+/ch/30/mix/09 ON   -oo +100 PRE 0
 /ch/30/mix/10 ON   -oo
-/ch/30/mix/11 ON  -1.5 +100 POST
+/ch/30/mix/11 ON  -1.5 +100 POST 0
 /ch/30/mix/12 ON  -1.5
-/ch/30/mix/13 ON   -oo +100 POST
+/ch/30/mix/13 ON   -oo +100 POST 0
 /ch/30/mix/14 ON   -oo
-/ch/30/mix/15 ON   -oo +100 POST
+/ch/30/mix/15 ON   -oo +100 POST 0
 /ch/30/mix/16 ON   -oo
 /ch/30/grp %01000000 %000000
 /ch/30/automix OFF  +0.0
@@ -1004,21 +1010,21 @@
 /ch/31/eq/3 PEQ 1k13 +0.50 2.0
 /ch/31/eq/4 HShv 10k02 +2.00 2.0
 /ch/31/mix ON   -oo ON +0 OFF -21.0
-/ch/31/mix/01 ON   -oo +0 POST
-/ch/31/mix/02 ON   -oo
-/ch/31/mix/03 ON   -oo +0 POST
-/ch/31/mix/04 ON   -oo
-/ch/31/mix/05 ON   -oo +0 POST
-/ch/31/mix/06 ON   -oo
-/ch/31/mix/07 ON   -oo +0 POST
-/ch/31/mix/08 ON   -oo
-/ch/31/mix/09 ON   -oo +0 POST
-/ch/31/mix/10 ON   -oo
-/ch/31/mix/11 ON  -0.8 +0 POST
+/ch/31/mix/01 ON -15.0 +0 POST 0
+/ch/31/mix/02 ON -15.0
+/ch/31/mix/03 ON -15.0 +0 POST 0
+/ch/31/mix/04 ON -15.0
+/ch/31/mix/05 ON -15.0 +0 POST 0
+/ch/31/mix/06 ON -15.0
+/ch/31/mix/07 ON -15.0 +0 POST 0
+/ch/31/mix/08 ON -15.0
+/ch/31/mix/09 ON -15.0 +0 POST 0
+/ch/31/mix/10 ON -15.0
+/ch/31/mix/11 ON  -0.8 +0 POST 0
 /ch/31/mix/12 ON  -0.8
-/ch/31/mix/13 ON   -oo +0 POST
+/ch/31/mix/13 ON   -oo +0 POST 0
 /ch/31/mix/14 OFF   -oo
-/ch/31/mix/15 OFF   -oo +0 POST
+/ch/31/mix/15 OFF   -oo +0 POST 0
 /ch/31/mix/16 OFF   -oo
 /ch/31/grp %01000000 %000000
 /ch/31/automix OFF  +0.0
@@ -1036,21 +1042,21 @@
 /ch/32/eq/3 PEQ 677.7 -1.50 1.2
 /ch/32/eq/4 HShv 7k34 -2.50 2.2
 /ch/32/mix ON   -oo ON +0 ON -26.5
-/ch/32/mix/01 ON   -oo +0 POST
-/ch/32/mix/02 ON   -oo
-/ch/32/mix/03 ON   -oo +0 POST
-/ch/32/mix/04 ON   -oo
-/ch/32/mix/05 ON   -oo +0 POST
-/ch/32/mix/06 ON   -oo
-/ch/32/mix/07 ON   -oo +0 POST
-/ch/32/mix/08 ON   -oo
-/ch/32/mix/09 ON   -oo +0 POST
-/ch/32/mix/10 ON   -oo
-/ch/32/mix/11 ON   0.0 +0 POST
+/ch/32/mix/01 ON -15.0 +0 POST 0
+/ch/32/mix/02 ON -15.0
+/ch/32/mix/03 ON -15.0 +0 POST 0
+/ch/32/mix/04 ON -15.0
+/ch/32/mix/05 ON -15.0 +0 POST 0
+/ch/32/mix/06 ON -15.0
+/ch/32/mix/07 ON -15.0 +0 POST 0
+/ch/32/mix/08 ON -15.0
+/ch/32/mix/09 ON -15.0 +0 POST 0
+/ch/32/mix/10 ON -15.0
+/ch/32/mix/11 ON   0.0 +0 POST 0
 /ch/32/mix/12 ON   0.0
-/ch/32/mix/13 ON   -oo +0 POST
+/ch/32/mix/13 ON   -oo +0 POST 0
 /ch/32/mix/14 OFF   -oo
-/ch/32/mix/15 OFF   -oo +0 POST
+/ch/32/mix/15 OFF   -oo +0 POST 0
 /ch/32/mix/16 OFF   -oo
 /ch/32/grp %01000000 %000000
 /ch/32/automix OFF  +0.0
@@ -1062,21 +1068,21 @@
 /auxin/01/eq/3 PEQ 1k97 +0.00 2.0
 /auxin/01/eq/4 HShv 10k02 +0.00 2.0
 /auxin/01/mix ON   -oo OFF +0 OFF   -oo
-/auxin/01/mix/01 ON   -oo +0 PRE
+/auxin/01/mix/01 ON   -oo +0 PRE 0
 /auxin/01/mix/02 ON   -oo
-/auxin/01/mix/03 ON   -oo +0 PRE
+/auxin/01/mix/03 ON   -oo +0 PRE 0
 /auxin/01/mix/04 ON   -oo
-/auxin/01/mix/05 ON   -oo +0 PRE
+/auxin/01/mix/05 ON   -oo +0 PRE 0
 /auxin/01/mix/06 ON   -oo
-/auxin/01/mix/07 ON   -oo +0 PRE
+/auxin/01/mix/07 ON   -oo +0 PRE 0
 /auxin/01/mix/08 ON   -oo
-/auxin/01/mix/09 ON   -oo +0 PRE
+/auxin/01/mix/09 ON   -oo +0 PRE 0
 /auxin/01/mix/10 ON   -oo
-/auxin/01/mix/11 ON   -oo +0 POST
+/auxin/01/mix/11 ON   -oo +0 POST 0
 /auxin/01/mix/12 ON   -oo
-/auxin/01/mix/13 ON   -oo +0 POST
+/auxin/01/mix/13 ON   -oo +0 POST 0
 /auxin/01/mix/14 ON   -oo
-/auxin/01/mix/15 ON   -oo +0 POST
+/auxin/01/mix/15 ON   -oo +0 POST 0
 /auxin/01/mix/16 ON   -oo
 /auxin/01/grp %00000000 %000000
 /auxin/02/config "" 1 OFFi 34
@@ -1087,21 +1093,21 @@
 /auxin/02/eq/3 PEQ 1k97 +0.00 2.0
 /auxin/02/eq/4 HShv 10k02 +0.00 2.0
 /auxin/02/mix ON   -oo OFF +0 OFF   -oo
-/auxin/02/mix/01 ON   -oo +0 PRE
+/auxin/02/mix/01 ON   -oo +0 PRE 0
 /auxin/02/mix/02 ON   -oo
-/auxin/02/mix/03 ON   -oo +0 PRE
+/auxin/02/mix/03 ON   -oo +0 PRE 0
 /auxin/02/mix/04 ON   -oo
-/auxin/02/mix/05 ON   -oo +0 PRE
+/auxin/02/mix/05 ON   -oo +0 PRE 0
 /auxin/02/mix/06 ON   -oo
-/auxin/02/mix/07 ON   -oo +0 PRE
+/auxin/02/mix/07 ON   -oo +0 PRE 0
 /auxin/02/mix/08 ON   -oo
-/auxin/02/mix/09 ON   -oo +0 PRE
+/auxin/02/mix/09 ON   -oo +0 PRE 0
 /auxin/02/mix/10 ON   -oo
-/auxin/02/mix/11 ON   -oo +0 POST
+/auxin/02/mix/11 ON   -oo +0 POST 0
 /auxin/02/mix/12 ON   -oo
-/auxin/02/mix/13 ON   -oo +0 POST
+/auxin/02/mix/13 ON   -oo +0 POST 0
 /auxin/02/mix/14 ON   -oo
-/auxin/02/mix/15 ON   -oo +0 POST
+/auxin/02/mix/15 ON   -oo +0 POST 0
 /auxin/02/mix/16 ON   -oo
 /auxin/02/grp %00000000 %000000
 /auxin/03/config "" 1 OFFi 35
@@ -1112,21 +1118,21 @@
 /auxin/03/eq/3 PEQ 1k97 +0.00 2.0
 /auxin/03/eq/4 HShv 10k02 +0.00 2.0
 /auxin/03/mix ON   -oo OFF +0 OFF   -oo
-/auxin/03/mix/01 ON   -oo +0 PRE
+/auxin/03/mix/01 ON   -oo +0 PRE 0
 /auxin/03/mix/02 ON   -oo
-/auxin/03/mix/03 ON   -oo +0 PRE
+/auxin/03/mix/03 ON   -oo +0 PRE 0
 /auxin/03/mix/04 ON   -oo
-/auxin/03/mix/05 ON   -oo +0 PRE
+/auxin/03/mix/05 ON   -oo +0 PRE 0
 /auxin/03/mix/06 ON   -oo
-/auxin/03/mix/07 ON   -oo +0 PRE
+/auxin/03/mix/07 ON   -oo +0 PRE 0
 /auxin/03/mix/08 ON   -oo
-/auxin/03/mix/09 ON   -oo +0 PRE
+/auxin/03/mix/09 ON   -oo +0 PRE 0
 /auxin/03/mix/10 ON   -oo
-/auxin/03/mix/11 ON   -oo +0 POST
+/auxin/03/mix/11 ON   -oo +0 POST 0
 /auxin/03/mix/12 ON   -oo
-/auxin/03/mix/13 ON   -oo +0 POST
+/auxin/03/mix/13 ON   -oo +0 POST 0
 /auxin/03/mix/14 ON   -oo
-/auxin/03/mix/15 ON   -oo +0 POST
+/auxin/03/mix/15 ON   -oo +0 POST 0
 /auxin/03/mix/16 ON   -oo
 /auxin/03/grp %00000000 %000000
 /auxin/04/config "" 1 OFFi 36
@@ -1137,21 +1143,21 @@
 /auxin/04/eq/3 PEQ 1k97 +0.00 2.0
 /auxin/04/eq/4 HShv 10k02 +0.00 2.0
 /auxin/04/mix ON   -oo OFF +0 OFF   -oo
-/auxin/04/mix/01 ON   -oo +0 PRE
+/auxin/04/mix/01 ON   -oo +0 PRE 0
 /auxin/04/mix/02 ON   -oo
-/auxin/04/mix/03 ON   -oo +0 PRE
+/auxin/04/mix/03 ON   -oo +0 PRE 0
 /auxin/04/mix/04 ON   -oo
-/auxin/04/mix/05 ON   -oo +0 PRE
+/auxin/04/mix/05 ON   -oo +0 PRE 0
 /auxin/04/mix/06 ON   -oo
-/auxin/04/mix/07 ON   -oo +0 PRE
+/auxin/04/mix/07 ON   -oo +0 PRE 0
 /auxin/04/mix/08 ON   -oo
-/auxin/04/mix/09 ON   -oo +0 PRE
+/auxin/04/mix/09 ON   -oo +0 PRE 0
 /auxin/04/mix/10 ON   -oo
-/auxin/04/mix/11 ON   -oo +0 POST
+/auxin/04/mix/11 ON   -oo +0 POST 0
 /auxin/04/mix/12 ON   -oo
-/auxin/04/mix/13 ON   -oo +0 POST
+/auxin/04/mix/13 ON   -oo +0 POST 0
 /auxin/04/mix/14 ON   -oo
-/auxin/04/mix/15 ON   -oo +0 POST
+/auxin/04/mix/15 ON   -oo +0 POST 0
 /auxin/04/mix/16 ON   -oo
 /auxin/04/grp %00000000 %000000
 /auxin/05/config "Bkg Music L" 1 CY 37
@@ -1162,21 +1168,21 @@
 /auxin/05/eq/3 PEQ 1k97 +0.00 2.0
 /auxin/05/eq/4 HShv 10k02 +0.00 2.0
 /auxin/05/mix ON  -5.0 ON -100 ON -10.0
-/auxin/05/mix/01 ON -21.0 -100 POST
+/auxin/05/mix/01 ON -21.0 -100 POST 0
 /auxin/05/mix/02 ON -21.0
-/auxin/05/mix/03 ON -21.0 -100 POST
+/auxin/05/mix/03 ON -21.0 -100 POST 0
 /auxin/05/mix/04 ON -21.0
-/auxin/05/mix/05 ON -21.0 -100 POST
+/auxin/05/mix/05 ON -21.0 -100 POST 0
 /auxin/05/mix/06 ON -21.0
-/auxin/05/mix/07 ON -21.0 -100 POST
+/auxin/05/mix/07 ON -21.0 -100 POST 0
 /auxin/05/mix/08 ON -21.0
-/auxin/05/mix/09 ON -21.0 -100 POST
+/auxin/05/mix/09 ON -21.0 -100 POST 0
 /auxin/05/mix/10 ON -21.0
-/auxin/05/mix/11 ON  -6.5 -100 POST
+/auxin/05/mix/11 ON  -6.5 -100 POST 0
 /auxin/05/mix/12 ON  -6.5
-/auxin/05/mix/13 ON -20.0 -100 POST
+/auxin/05/mix/13 ON -20.0 -100 POST 0
 /auxin/05/mix/14 ON   -oo
-/auxin/05/mix/15 ON   -oo -100 POST
+/auxin/05/mix/15 ON   -oo -100 POST 0
 /auxin/05/mix/16 ON   -oo
 /auxin/05/grp %00001000 %000000
 /auxin/06/config "Bkg Music R" 1 CY 38
@@ -1187,21 +1193,21 @@
 /auxin/06/eq/3 PEQ 1k97 +0.00 2.0
 /auxin/06/eq/4 HShv 10k02 +0.00 2.0
 /auxin/06/mix ON  -5.0 ON -100 ON -10.0
-/auxin/06/mix/01 ON -21.0 +100 POST
+/auxin/06/mix/01 ON -21.0 +100 POST 0
 /auxin/06/mix/02 ON -21.0
-/auxin/06/mix/03 ON -21.0 +100 POST
+/auxin/06/mix/03 ON -21.0 +100 POST 0
 /auxin/06/mix/04 ON -21.0
-/auxin/06/mix/05 ON -21.0 +100 POST
+/auxin/06/mix/05 ON -21.0 +100 POST 0
 /auxin/06/mix/06 ON -21.0
-/auxin/06/mix/07 ON -21.0 +100 POST
+/auxin/06/mix/07 ON -21.0 +100 POST 0
 /auxin/06/mix/08 ON -21.0
-/auxin/06/mix/09 ON -21.0 +100 POST
+/auxin/06/mix/09 ON -21.0 +100 POST 0
 /auxin/06/mix/10 ON -21.0
-/auxin/06/mix/11 ON  -6.5 +100 POST
+/auxin/06/mix/11 ON  -6.5 +100 POST 0
 /auxin/06/mix/12 ON  -6.5
-/auxin/06/mix/13 ON -20.0 +100 POST
+/auxin/06/mix/13 ON -20.0 +100 POST 0
 /auxin/06/mix/14 ON   -oo
-/auxin/06/mix/15 ON   -oo +100 POST
+/auxin/06/mix/15 ON   -oo +100 POST 0
 /auxin/06/mix/16 ON   -oo
 /auxin/06/grp %00001000 %000000
 /auxin/07/config "USB L" 60 CY 39
@@ -1212,21 +1218,21 @@
 /auxin/07/eq/3 PEQ 1k97 +0.00 2.0
 /auxin/07/eq/4 HShv 10k02 +0.00 2.0
 /auxin/07/mix ON   -oo ON -100 OFF   -oo
-/auxin/07/mix/01 ON   -oo +0 PRE
+/auxin/07/mix/01 ON   -oo +0 PRE 0
 /auxin/07/mix/02 ON   -oo
-/auxin/07/mix/03 ON   -oo +0 PRE
+/auxin/07/mix/03 ON   -oo +0 PRE 0
 /auxin/07/mix/04 ON   -oo
-/auxin/07/mix/05 ON   -oo +0 PRE
+/auxin/07/mix/05 ON   -oo +0 PRE 0
 /auxin/07/mix/06 ON   -oo
-/auxin/07/mix/07 ON   -oo +0 PRE
+/auxin/07/mix/07 ON   -oo +0 PRE 0
 /auxin/07/mix/08 ON   -oo
-/auxin/07/mix/09 ON   -oo +0 PRE
+/auxin/07/mix/09 ON   -oo +0 PRE 0
 /auxin/07/mix/10 ON   -oo
-/auxin/07/mix/11 ON   -oo +0 POST
+/auxin/07/mix/11 ON   -oo +0 POST 0
 /auxin/07/mix/12 ON   -oo
-/auxin/07/mix/13 ON   -oo +0 POST
+/auxin/07/mix/13 ON   -oo +0 POST 0
 /auxin/07/mix/14 ON   -oo
-/auxin/07/mix/15 ON   -oo +0 POST
+/auxin/07/mix/15 ON   -oo +0 POST 0
 /auxin/07/mix/16 ON   -oo
 /auxin/07/grp %00001000 %000000
 /auxin/08/config "USB R" 60 CY 40
@@ -1237,21 +1243,21 @@
 /auxin/08/eq/3 PEQ 1k97 +0.00 2.0
 /auxin/08/eq/4 HShv 10k02 +0.00 2.0
 /auxin/08/mix ON   -oo ON +100 OFF   -oo
-/auxin/08/mix/01 ON   -oo +0 PRE
+/auxin/08/mix/01 ON   -oo +0 PRE 0
 /auxin/08/mix/02 ON   -oo
-/auxin/08/mix/03 ON   -oo +0 PRE
+/auxin/08/mix/03 ON   -oo +0 PRE 0
 /auxin/08/mix/04 ON   -oo
-/auxin/08/mix/05 ON   -oo +0 PRE
+/auxin/08/mix/05 ON   -oo +0 PRE 0
 /auxin/08/mix/06 ON   -oo
-/auxin/08/mix/07 ON   -oo +0 PRE
+/auxin/08/mix/07 ON   -oo +0 PRE 0
 /auxin/08/mix/08 ON   -oo
-/auxin/08/mix/09 ON   -oo +0 PRE
+/auxin/08/mix/09 ON   -oo +0 PRE 0
 /auxin/08/mix/10 ON   -oo
-/auxin/08/mix/11 ON   -oo +0 POST
+/auxin/08/mix/11 ON   -oo +0 POST 0
 /auxin/08/mix/12 ON   -oo
-/auxin/08/mix/13 ON   -oo +0 POST
+/auxin/08/mix/13 ON   -oo +0 POST 0
 /auxin/08/mix/14 ON   -oo
-/auxin/08/mix/15 ON   -oo +0 POST
+/auxin/08/mix/15 ON   -oo +0 POST 0
 /auxin/08/mix/16 ON   -oo
 /auxin/08/grp %00001000 %000000
 /fxrtn/01/config "acu rev" 1 MG
@@ -1261,23 +1267,23 @@
 /fxrtn/01/eq/3 PEQ 1k97 +0.00 2.0
 /fxrtn/01/eq/4 HShv 10k02 +0.00 2.0
 /fxrtn/01/mix ON   0.0 ON -100 OFF   -oo
-/fxrtn/01/mix/01 ON -20.0 -100 POST
-/fxrtn/01/mix/02 ON -20.0
-/fxrtn/01/mix/03 ON -20.0 -100 POST
-/fxrtn/01/mix/04 ON -20.0
-/fxrtn/01/mix/05 ON -12.0 -100 POST
-/fxrtn/01/mix/06 ON -12.0
-/fxrtn/01/mix/07 ON -20.0 -100 POST
-/fxrtn/01/mix/08 ON -20.0
-/fxrtn/01/mix/09 ON -18.5 -100 POST
-/fxrtn/01/mix/10 ON -18.5
-/fxrtn/01/mix/11 ON  +5.0 -100 POST
+/fxrtn/01/mix/01 ON   -oo -100 POST 0
+/fxrtn/01/mix/02 ON   -oo
+/fxrtn/01/mix/03 ON   -oo -100 POST 0
+/fxrtn/01/mix/04 ON   -oo
+/fxrtn/01/mix/05 ON -21.0 -100 POST 0
+/fxrtn/01/mix/06 ON -21.0
+/fxrtn/01/mix/07 ON   -oo -100 POST 0
+/fxrtn/01/mix/08 ON   -oo
+/fxrtn/01/mix/09 ON   -oo -100 POST 0
+/fxrtn/01/mix/10 ON   -oo
+/fxrtn/01/mix/11 ON  +5.0 -100 POST 0
 /fxrtn/01/mix/12 ON  +5.0
-/fxrtn/01/mix/13 ON -20.0 -100 POST
+/fxrtn/01/mix/13 ON -20.0 -100 POST 0
 /fxrtn/01/mix/14 OFF   -oo
-/fxrtn/01/mix/15 OFF   -oo -100 POST
+/fxrtn/01/mix/15 OFF   -oo -100 POST 0
 /fxrtn/01/mix/16 OFF   -oo
-/fxrtn/01/grp %00100000 %000000
+/fxrtn/01/grp %00000000 %000000
 /fxrtn/02/config "acu rev" 1 MG
 /fxrtn/02/eq ON
 /fxrtn/02/eq/1 LCut 176.2 +0.00 2.0
@@ -1285,23 +1291,23 @@
 /fxrtn/02/eq/3 PEQ 1k97 +0.00 2.0
 /fxrtn/02/eq/4 HShv 10k02 +0.00 2.0
 /fxrtn/02/mix ON   0.0 ON +100 OFF   -oo
-/fxrtn/02/mix/01 ON -20.0 +100 POST
-/fxrtn/02/mix/02 ON -20.0
-/fxrtn/02/mix/03 ON -20.0 +100 POST
-/fxrtn/02/mix/04 ON -20.0
-/fxrtn/02/mix/05 ON -12.0 +100 POST
-/fxrtn/02/mix/06 ON -12.0
-/fxrtn/02/mix/07 ON -20.0 +100 POST
-/fxrtn/02/mix/08 ON -20.0
-/fxrtn/02/mix/09 ON -18.5 +100 POST
-/fxrtn/02/mix/10 ON -18.5
-/fxrtn/02/mix/11 ON  +5.0 +100 POST
+/fxrtn/02/mix/01 ON   -oo +100 POST 0
+/fxrtn/02/mix/02 ON   -oo
+/fxrtn/02/mix/03 ON   -oo +100 POST 0
+/fxrtn/02/mix/04 ON   -oo
+/fxrtn/02/mix/05 ON -21.0 +100 POST 0
+/fxrtn/02/mix/06 ON -21.0
+/fxrtn/02/mix/07 ON   -oo +100 POST 0
+/fxrtn/02/mix/08 ON   -oo
+/fxrtn/02/mix/09 ON   -oo +100 POST 0
+/fxrtn/02/mix/10 ON   -oo
+/fxrtn/02/mix/11 ON  +5.0 +100 POST 0
 /fxrtn/02/mix/12 ON  +5.0
-/fxrtn/02/mix/13 ON -20.0 +100 POST
+/fxrtn/02/mix/13 ON -20.0 +100 POST 0
 /fxrtn/02/mix/14 OFF   -oo
-/fxrtn/02/mix/15 OFF   -oo +100 POST
+/fxrtn/02/mix/15 OFF   -oo +100 POST 0
 /fxrtn/02/mix/16 OFF   -oo
-/fxrtn/02/grp %00100000 %000000
+/fxrtn/02/grp %00000000 %000000
 /fxrtn/03/config "vox rev" 1 MG
 /fxrtn/03/eq ON
 /fxrtn/03/eq/1 LCut 164.4 +0.00 2.0
@@ -1309,23 +1315,23 @@
 /fxrtn/03/eq/3 PEQ 990.9 +2.50 0.8
 /fxrtn/03/eq/4 HShv 3k94 -10.7 2.0
 /fxrtn/03/mix ON   0.0 ON -100 OFF   -oo
-/fxrtn/03/mix/01 ON -20.0 -100 POST
-/fxrtn/03/mix/02 ON -20.0
-/fxrtn/03/mix/03 ON -20.0 -100 POST
-/fxrtn/03/mix/04 ON -20.0
-/fxrtn/03/mix/05 ON -20.0 -100 POST
-/fxrtn/03/mix/06 ON -20.0
-/fxrtn/03/mix/07 ON -20.0 -100 POST
-/fxrtn/03/mix/08 ON -20.0
-/fxrtn/03/mix/09 ON -12.0 -100 POST
-/fxrtn/03/mix/10 ON -12.0
-/fxrtn/03/mix/11 ON  +4.8 -100 POST
+/fxrtn/03/mix/01 ON   -oo -100 POST 0
+/fxrtn/03/mix/02 ON   -oo
+/fxrtn/03/mix/03 ON   -oo -100 POST 0
+/fxrtn/03/mix/04 ON   -oo
+/fxrtn/03/mix/05 ON   -oo -100 POST 0
+/fxrtn/03/mix/06 ON   -oo
+/fxrtn/03/mix/07 ON   -oo -100 POST 0
+/fxrtn/03/mix/08 ON   -oo
+/fxrtn/03/mix/09 ON -21.0 -100 POST 0
+/fxrtn/03/mix/10 ON -21.0
+/fxrtn/03/mix/11 ON  +4.8 -100 POST 0
 /fxrtn/03/mix/12 ON  +4.8
-/fxrtn/03/mix/13 ON   -oo -100 POST
+/fxrtn/03/mix/13 ON   -oo -100 POST 0
 /fxrtn/03/mix/14 OFF   -oo
-/fxrtn/03/mix/15 OFF   -oo -100 POST
+/fxrtn/03/mix/15 OFF   -oo -100 POST 0
 /fxrtn/03/mix/16 OFF   -oo
-/fxrtn/03/grp %00100000 %000000
+/fxrtn/03/grp %00000000 %000000
 /fxrtn/04/config "vox rev" 1 MG
 /fxrtn/04/eq ON
 /fxrtn/04/eq/1 LCut 164.4 +0.00 2.0
@@ -1333,71 +1339,71 @@
 /fxrtn/04/eq/3 PEQ 990.9 +2.50 0.8
 /fxrtn/04/eq/4 HShv 3k94 -10.7 2.0
 /fxrtn/04/mix ON   0.0 ON +100 OFF   -oo
-/fxrtn/04/mix/01 ON -20.0 +100 POST
-/fxrtn/04/mix/02 ON -20.0
-/fxrtn/04/mix/03 ON -20.0 +100 POST
-/fxrtn/04/mix/04 ON -20.0
-/fxrtn/04/mix/05 ON -20.0 +100 POST
-/fxrtn/04/mix/06 ON -20.0
-/fxrtn/04/mix/07 ON -20.0 +100 POST
-/fxrtn/04/mix/08 ON -20.0
-/fxrtn/04/mix/09 ON -12.0 +0 POST
-/fxrtn/04/mix/10 ON -12.0
-/fxrtn/04/mix/11 ON  +4.8 +100 POST
+/fxrtn/04/mix/01 ON   -oo +100 POST 0
+/fxrtn/04/mix/02 ON   -oo
+/fxrtn/04/mix/03 ON   -oo +100 POST 0
+/fxrtn/04/mix/04 ON   -oo
+/fxrtn/04/mix/05 ON   -oo +100 POST 0
+/fxrtn/04/mix/06 ON   -oo
+/fxrtn/04/mix/07 ON   -oo +100 POST 0
+/fxrtn/04/mix/08 ON   -oo
+/fxrtn/04/mix/09 ON -21.0 +0 POST 0
+/fxrtn/04/mix/10 ON -21.0
+/fxrtn/04/mix/11 ON  +4.8 +100 POST 0
 /fxrtn/04/mix/12 ON  +4.8
-/fxrtn/04/mix/13 ON   -oo +100 POST
+/fxrtn/04/mix/13 ON   -oo +100 POST 0
 /fxrtn/04/mix/14 OFF   -oo
-/fxrtn/04/mix/15 OFF   -oo +100 POST
+/fxrtn/04/mix/15 OFF   -oo +100 POST 0
 /fxrtn/04/mix/16 OFF   -oo
-/fxrtn/04/grp %00100000 %000000
+/fxrtn/04/grp %00000000 %000000
 /fxrtn/05/config "slap delay" 1 MG
 /fxrtn/05/eq ON
 /fxrtn/05/eq/1 LCut 532.1 +0.50 2.0
 /fxrtn/05/eq/2 PEQ 496.6 +0.00 2.0
 /fxrtn/05/eq/3 PEQ 1k97 +0.00 2.0
 /fxrtn/05/eq/4 HCut 2k27 +0.50 2.0
-/fxrtn/05/mix ON   -oo ON -100 OFF   -oo
-/fxrtn/05/mix/01 ON -20.0 -100 POST
-/fxrtn/05/mix/02 ON -20.0
-/fxrtn/05/mix/03 ON -20.0 -100 POST
-/fxrtn/05/mix/04 ON -20.0
-/fxrtn/05/mix/05 ON -20.0 -100 POST
-/fxrtn/05/mix/06 ON -20.0
-/fxrtn/05/mix/07 ON -20.0 -100 POST
-/fxrtn/05/mix/08 ON -20.0
-/fxrtn/05/mix/09 ON -20.0 -100 POST
-/fxrtn/05/mix/10 ON -20.0
-/fxrtn/05/mix/11 ON  +4.0 -100 POST
+/fxrtn/05/mix ON   0.0 ON -100 OFF   -oo
+/fxrtn/05/mix/01 ON   -oo -100 POST 0
+/fxrtn/05/mix/02 ON   -oo
+/fxrtn/05/mix/03 ON   -oo -100 POST 0
+/fxrtn/05/mix/04 ON   -oo
+/fxrtn/05/mix/05 ON   -oo -100 POST 0
+/fxrtn/05/mix/06 ON   -oo
+/fxrtn/05/mix/07 ON   -oo -100 POST 0
+/fxrtn/05/mix/08 ON   -oo
+/fxrtn/05/mix/09 ON -21.0 -100 POST 0
+/fxrtn/05/mix/10 ON -21.0
+/fxrtn/05/mix/11 ON  +4.0 -100 POST 0
 /fxrtn/05/mix/12 ON  +4.0
-/fxrtn/05/mix/13 ON -20.0 +0 POST
+/fxrtn/05/mix/13 ON -20.0 +0 POST 0
 /fxrtn/05/mix/14 OFF   -oo
-/fxrtn/05/mix/15 OFF   -oo +0 POST
+/fxrtn/05/mix/15 OFF   -oo +0 POST 0
 /fxrtn/05/mix/16 OFF   -oo
-/fxrtn/05/grp %00100000 %000000
+/fxrtn/05/grp %00000000 %000000
 /fxrtn/06/config "slap delay" 1 MG
 /fxrtn/06/eq ON
 /fxrtn/06/eq/1 LCut 532.1 +0.50 2.0
 /fxrtn/06/eq/2 PEQ 496.6 +0.00 2.0
 /fxrtn/06/eq/3 PEQ 1k97 +0.00 2.0
 /fxrtn/06/eq/4 HCut 2k27 +0.50 2.0
-/fxrtn/06/mix ON   -oo ON +100 OFF   -oo
-/fxrtn/06/mix/01 ON -20.0 +100 POST
-/fxrtn/06/mix/02 ON -20.0
-/fxrtn/06/mix/03 ON -20.0 +100 POST
-/fxrtn/06/mix/04 ON -20.0
-/fxrtn/06/mix/05 ON -20.0 +100 POST
-/fxrtn/06/mix/06 ON -20.0
-/fxrtn/06/mix/07 ON -20.0 +100 POST
-/fxrtn/06/mix/08 ON -20.0
-/fxrtn/06/mix/09 ON -20.0 +100 POST
-/fxrtn/06/mix/10 ON -20.0
-/fxrtn/06/mix/11 ON  +4.0 +100 POST
+/fxrtn/06/mix ON   0.0 ON +100 OFF   -oo
+/fxrtn/06/mix/01 ON   -oo +100 POST 0
+/fxrtn/06/mix/02 ON   -oo
+/fxrtn/06/mix/03 ON   -oo +100 POST 0
+/fxrtn/06/mix/04 ON   -oo
+/fxrtn/06/mix/05 ON   -oo +100 POST 0
+/fxrtn/06/mix/06 ON   -oo
+/fxrtn/06/mix/07 ON   -oo +100 POST 0
+/fxrtn/06/mix/08 ON   -oo
+/fxrtn/06/mix/09 ON -21.0 +100 POST 0
+/fxrtn/06/mix/10 ON -21.0
+/fxrtn/06/mix/11 ON  +4.0 +100 POST 0
 /fxrtn/06/mix/12 ON  +4.0
-/fxrtn/06/mix/13 ON -20.0 +0 POST
+/fxrtn/06/mix/13 ON -20.0 +0 POST 0
 /fxrtn/06/mix/14 OFF   -oo
-/fxrtn/06/mix/15 OFF   -oo +0 POST
+/fxrtn/06/mix/15 OFF   -oo +0 POST 0
 /fxrtn/06/mix/16 OFF   -oo
-/fxrtn/06/grp %00100000 %000000
+/fxrtn/06/grp %00000000 %000000
 /fxrtn/07/config "" 1 MG
 /fxrtn/07/eq OFF
 /fxrtn/07/eq/1 PEQ 124.7 +0.00 2.0
@@ -1405,23 +1411,23 @@
 /fxrtn/07/eq/3 PEQ 1k97 +0.00 2.0
 /fxrtn/07/eq/4 HShv 10k02 +0.00 2.0
 /fxrtn/07/mix ON   -oo ON -100 OFF   -oo
-/fxrtn/07/mix/01 ON   -oo +0 PRE
+/fxrtn/07/mix/01 ON   -oo +0 PRE 0
 /fxrtn/07/mix/02 ON   -oo
-/fxrtn/07/mix/03 ON   -oo +0 PRE
+/fxrtn/07/mix/03 ON   -oo +0 PRE 0
 /fxrtn/07/mix/04 ON   -oo
-/fxrtn/07/mix/05 ON   -oo +0 PRE
+/fxrtn/07/mix/05 ON   -oo +0 PRE 0
 /fxrtn/07/mix/06 ON   -oo
-/fxrtn/07/mix/07 ON   -oo +0 PRE
+/fxrtn/07/mix/07 ON   -oo +0 PRE 0
 /fxrtn/07/mix/08 ON   -oo
-/fxrtn/07/mix/09 ON   -oo +0 PRE
+/fxrtn/07/mix/09 ON   -oo +0 PRE 0
 /fxrtn/07/mix/10 ON   -oo
-/fxrtn/07/mix/11 ON   -oo +0 POST
+/fxrtn/07/mix/11 ON   -oo +0 POST 0
 /fxrtn/07/mix/12 ON   -oo
-/fxrtn/07/mix/13 ON   -oo +0 POST
+/fxrtn/07/mix/13 ON   -oo +0 POST 0
 /fxrtn/07/mix/14 ON   -oo
-/fxrtn/07/mix/15 ON   -oo +0 POST
+/fxrtn/07/mix/15 ON   -oo +0 POST 0
 /fxrtn/07/mix/16 ON   -oo
-/fxrtn/07/grp %00100000 %000000
+/fxrtn/07/grp %00000000 %000000
 /fxrtn/08/config "" 1 MG
 /fxrtn/08/eq OFF
 /fxrtn/08/eq/1 PEQ 124.7 +0.00 2.0
@@ -1429,23 +1435,23 @@
 /fxrtn/08/eq/3 PEQ 1k97 +0.00 2.0
 /fxrtn/08/eq/4 HShv 10k02 +0.00 2.0
 /fxrtn/08/mix ON   -oo ON +100 OFF   -oo
-/fxrtn/08/mix/01 ON   -oo +0 PRE
+/fxrtn/08/mix/01 ON   -oo +0 PRE 0
 /fxrtn/08/mix/02 ON   -oo
-/fxrtn/08/mix/03 ON   -oo +0 PRE
+/fxrtn/08/mix/03 ON   -oo +0 PRE 0
 /fxrtn/08/mix/04 ON   -oo
-/fxrtn/08/mix/05 ON   -oo +0 PRE
+/fxrtn/08/mix/05 ON   -oo +0 PRE 0
 /fxrtn/08/mix/06 ON   -oo
-/fxrtn/08/mix/07 ON   -oo +0 PRE
+/fxrtn/08/mix/07 ON   -oo +0 PRE 0
 /fxrtn/08/mix/08 ON   -oo
-/fxrtn/08/mix/09 ON   -oo +0 PRE
+/fxrtn/08/mix/09 ON   -oo +0 PRE 0
 /fxrtn/08/mix/10 ON   -oo
-/fxrtn/08/mix/11 ON   -oo +0 POST
+/fxrtn/08/mix/11 ON   -oo +0 POST 0
 /fxrtn/08/mix/12 ON   -oo
-/fxrtn/08/mix/13 ON   -oo +0 POST
+/fxrtn/08/mix/13 ON   -oo +0 POST 0
 /fxrtn/08/mix/14 ON   -oo
-/fxrtn/08/mix/15 ON   -oo +0 POST
+/fxrtn/08/mix/15 ON   -oo +0 POST 0
 /fxrtn/08/mix/16 ON   -oo
-/fxrtn/08/grp %00100000 %000000
+/fxrtn/08/grp %00000000 %000000
 /bus/01/config "Drums L" 1 CY
 /bus/01/dyn ON COMP RMS LOG -1.0 100 0 0.00 0 0.02  471 POST 0 100 OFF
 /bus/01/dyn/filter OFF 3.0 990.9
@@ -1458,11 +1464,11 @@
 /bus/01/eq/5 PEQ 5k02 +0.00 2.0
 /bus/01/eq/6 HShv 10k02 +0.00 2.0
 /bus/01/mix ON   0.0 OFF -100 OFF   -oo
-/bus/01/mix/01 OFF   -oo -100 POST
+/bus/01/mix/01 OFF   -oo -100 POST 0
 /bus/01/mix/02 OFF   -oo
-/bus/01/mix/03 OFF   -oo -100 POST
+/bus/01/mix/03 OFF   -oo -100 POST 0
 /bus/01/mix/04 OFF   -oo
-/bus/01/mix/05 OFF   -oo -100 POST
+/bus/01/mix/05 OFF   -oo -100 POST 0
 /bus/01/mix/06 OFF   -oo
 /bus/01/grp %00000000 %000000
 /bus/02/config "Drums R" 1 CY
@@ -1477,11 +1483,11 @@
 /bus/02/eq/5 PEQ 5k02 +0.00 2.0
 /bus/02/eq/6 HShv 10k02 +0.00 2.0
 /bus/02/mix ON   0.0 OFF +100 OFF   -oo
-/bus/02/mix/01 OFF   -oo +100 POST
+/bus/02/mix/01 OFF   -oo +100 POST 0
 /bus/02/mix/02 OFF   -oo
-/bus/02/mix/03 OFF   -oo +100 POST
+/bus/02/mix/03 OFF   -oo +100 POST 0
 /bus/02/mix/04 OFF   -oo
-/bus/02/mix/05 OFF   -oo +100 POST
+/bus/02/mix/05 OFF   -oo +100 POST 0
 /bus/02/mix/06 OFF   -oo
 /bus/02/grp %00000000 %000000
 /bus/03/config "Bass L" 1 CY
@@ -1496,11 +1502,11 @@
 /bus/03/eq/5 PEQ 5k02 +0.00 2.0
 /bus/03/eq/6 HShv 10k02 +0.00 2.0
 /bus/03/mix ON   0.0 OFF -100 OFF   -oo
-/bus/03/mix/01 OFF   -oo -100 POST
+/bus/03/mix/01 OFF   -oo -100 POST 0
 /bus/03/mix/02 OFF   -oo
-/bus/03/mix/03 OFF   -oo -100 POST
+/bus/03/mix/03 OFF   -oo -100 POST 0
 /bus/03/mix/04 OFF   -oo
-/bus/03/mix/05 OFF   -oo -100 POST
+/bus/03/mix/05 OFF   -oo -100 POST 0
 /bus/03/mix/06 OFF   -oo
 /bus/03/grp %00000000 %000000
 /bus/04/config "Bass R" 1 CY
@@ -1515,11 +1521,11 @@
 /bus/04/eq/5 PEQ 5k02 +0.00 2.0
 /bus/04/eq/6 HShv 10k02 +0.00 2.0
 /bus/04/mix ON   0.0 OFF +100 OFF   -oo
-/bus/04/mix/01 OFF   -oo +100 POST
+/bus/04/mix/01 OFF   -oo +100 POST 0
 /bus/04/mix/02 OFF   -oo
-/bus/04/mix/03 OFF   -oo +100 POST
+/bus/04/mix/03 OFF   -oo +100 POST 0
 /bus/04/mix/04 OFF   -oo
-/bus/04/mix/05 OFF   -oo +100 POST
+/bus/04/mix/05 OFF   -oo +100 POST 0
 /bus/04/mix/06 OFF   -oo
 /bus/04/grp %00000000 %000000
 /bus/05/config "Git L" 1 CY
@@ -1534,11 +1540,11 @@
 /bus/05/eq/5 PEQ 5k02 +0.00 2.0
 /bus/05/eq/6 HShv 10k02 +0.00 2.0
 /bus/05/mix ON   0.0 OFF -100 OFF   -oo
-/bus/05/mix/01 OFF   -oo -100 POST
+/bus/05/mix/01 OFF   -oo -100 POST 0
 /bus/05/mix/02 OFF   -oo
-/bus/05/mix/03 OFF   -oo -100 POST
+/bus/05/mix/03 OFF   -oo -100 POST 0
 /bus/05/mix/04 OFF   -oo
-/bus/05/mix/05 ON   -oo -100 POST
+/bus/05/mix/05 ON   -oo -100 POST 0
 /bus/05/mix/06 ON   -oo
 /bus/05/grp %00000000 %000000
 /bus/06/config "Git R" 1 CY
@@ -1553,11 +1559,11 @@
 /bus/06/eq/5 PEQ 5k02 +0.00 2.0
 /bus/06/eq/6 HShv 10k02 +0.00 2.0
 /bus/06/mix ON   0.0 OFF +100 OFF   -oo
-/bus/06/mix/01 OFF   -oo +100 POST
+/bus/06/mix/01 OFF   -oo +100 POST 0
 /bus/06/mix/02 OFF   -oo
-/bus/06/mix/03 OFF   -oo +100 POST
+/bus/06/mix/03 OFF   -oo +100 POST 0
 /bus/06/mix/04 OFF   -oo
-/bus/06/mix/05 ON   -oo +100 POST
+/bus/06/mix/05 ON   -oo +100 POST 0
 /bus/06/mix/06 ON   -oo
 /bus/06/grp %00000000 %000000
 /bus/07/config "Keys L" 1 CY
@@ -1572,11 +1578,11 @@
 /bus/07/eq/5 PEQ 5k02 +0.00 2.0
 /bus/07/eq/6 HShv 10k02 +0.00 2.0
 /bus/07/mix ON   0.0 OFF -100 OFF   -oo
-/bus/07/mix/01 OFF   -oo -100 POST
+/bus/07/mix/01 OFF   -oo -100 POST 0
 /bus/07/mix/02 OFF   -oo
-/bus/07/mix/03 OFF   -oo -100 POST
+/bus/07/mix/03 OFF   -oo -100 POST 0
 /bus/07/mix/04 OFF   -oo
-/bus/07/mix/05 ON   -oo -100 POST
+/bus/07/mix/05 ON   -oo -100 POST 0
 /bus/07/mix/06 ON   -oo
 /bus/07/grp %00000000 %000000
 /bus/08/config "Keys R" 1 CY
@@ -1591,11 +1597,11 @@
 /bus/08/eq/5 PEQ 5k02 +0.00 2.0
 /bus/08/eq/6 HShv 10k02 +0.00 2.0
 /bus/08/mix ON   0.0 OFF +100 OFF   -oo
-/bus/08/mix/01 OFF   -oo +100 POST
+/bus/08/mix/01 OFF   -oo +100 POST 0
 /bus/08/mix/02 OFF   -oo
-/bus/08/mix/03 OFF   -oo +100 POST
+/bus/08/mix/03 OFF   -oo +100 POST 0
 /bus/08/mix/04 OFF   -oo
-/bus/08/mix/05 ON   -oo +100 POST
+/bus/08/mix/05 ON   -oo +100 POST 0
 /bus/08/mix/06 ON   -oo
 /bus/08/grp %00000000 %000000
 /bus/09/config "Vox L" 1 CY
@@ -1610,11 +1616,11 @@
 /bus/09/eq/5 PEQ 5k02 +0.00 2.0
 /bus/09/eq/6 HShv 10k02 +0.00 2.0
 /bus/09/mix ON   0.0 OFF -100 OFF   -oo
-/bus/09/mix/01 OFF   -oo -100 POST
+/bus/09/mix/01 OFF   -oo -100 POST 0
 /bus/09/mix/02 OFF   -oo
-/bus/09/mix/03 OFF   -oo -100 POST
+/bus/09/mix/03 OFF   -oo -100 POST 0
 /bus/09/mix/04 OFF   -oo
-/bus/09/mix/05 ON   -oo -100 POST
+/bus/09/mix/05 ON   -oo -100 POST 0
 /bus/09/mix/06 ON   -oo
 /bus/09/grp %00000000 %000000
 /bus/10/config "Vox R" 1 CY
@@ -1629,11 +1635,11 @@
 /bus/10/eq/5 PEQ 5k02 +0.00 2.0
 /bus/10/eq/6 HShv 10k02 +0.00 2.0
 /bus/10/mix ON   0.0 OFF +100 OFF   -oo
-/bus/10/mix/01 OFF   -oo +100 POST
+/bus/10/mix/01 OFF   -oo +100 POST 0
 /bus/10/mix/02 OFF   -oo
-/bus/10/mix/03 OFF   -oo +100 POST
+/bus/10/mix/03 OFF   -oo +100 POST 0
 /bus/10/mix/04 OFF   -oo
-/bus/10/mix/05 ON   -oo +100 POST
+/bus/10/mix/05 ON   -oo +100 POST 0
 /bus/10/mix/06 ON   -oo
 /bus/10/grp %00000000 %000000
 /bus/11/config "Stream L" 1 WH
@@ -1648,11 +1654,11 @@
 /bus/11/eq/5 PEQ 5k02 +0.00 2.0
 /bus/11/eq/6 HShv 10k02 +0.00 2.0
 /bus/11/mix ON  -5.5 OFF -100 OFF   -oo
-/bus/11/mix/01 OFF   -oo -100 POST
+/bus/11/mix/01 OFF   -oo -100 POST 0
 /bus/11/mix/02 OFF   -oo
-/bus/11/mix/03 OFF   -oo -100 POST
+/bus/11/mix/03 OFF   -oo -100 POST 0
 /bus/11/mix/04 OFF   -oo
-/bus/11/mix/05 ON  +0.5 -94 POST
+/bus/11/mix/05 ON  +0.5 -94 POST 0
 /bus/11/mix/06 ON  +0.5
 /bus/11/grp %00000000 %000000
 /bus/12/config "Stream R" 1 WH
@@ -1667,30 +1673,30 @@
 /bus/12/eq/5 PEQ 5k02 +0.00 2.0
 /bus/12/eq/6 HShv 10k02 +0.00 2.0
 /bus/12/mix ON  -5.5 OFF +100 OFF   -oo
-/bus/12/mix/01 OFF   -oo +100 POST
+/bus/12/mix/01 OFF   -oo +100 POST 0
 /bus/12/mix/02 OFF   -oo
-/bus/12/mix/03 OFF   -oo +100 POST
+/bus/12/mix/03 OFF   -oo +100 POST 0
 /bus/12/mix/04 OFF   -oo
-/bus/12/mix/05 ON  +0.5 +100 POST
+/bus/12/mix/05 ON  +0.5 +100 POST 0
 /bus/12/mix/06 ON  +0.5
 /bus/12/grp %00000000 %000000
-/bus/13/config "" 1 OFF
-/bus/13/dyn ON COMP RMS LOG -1.0 100 0 0.00 0 0.02  504 POST 0 100 OFF
+/bus/13/config "DRUM SMACK" 1 RD
+/bus/13/dyn OFF COMP RMS LOG -1.0 100 0 0.00 0 0.02  504 POST 0 100 OFF
 /bus/13/dyn/filter OFF 3.0 990.9
-/bus/13/insert OFF POST OFF
+/bus/13/insert ON POST FX6L
 /bus/13/eq OFF
-/bus/13/eq/1 LShv 79.6 +0.00 2.0
-/bus/13/eq/2 PEQ 158.9 +0.00 2.0
+/bus/13/eq/1 LCut 138.4 -2.00 2.0
+/bus/13/eq/2 PEQ 295.8 -10.0 1.0
 /bus/13/eq/3 PEQ 496.6 +0.00 2.0
-/bus/13/eq/4 PEQ 1k97 +0.00 2.0
+/bus/13/eq/4 PEQ 590.2 +0.00 2.0
 /bus/13/eq/5 PEQ 5k02 +0.00 2.0
-/bus/13/eq/6 HShv 10k02 +0.00 2.0
-/bus/13/mix ON   -oo OFF +0 OFF   -oo
-/bus/13/mix/01 OFF   -oo -100 POST
+/bus/13/eq/6 HCut 2k99 +0.00 2.0
+/bus/13/mix ON -12.0 ON +0 ON   -oo
+/bus/13/mix/01 OFF   -oo -100 POST 0
 /bus/13/mix/02 OFF   -oo
-/bus/13/mix/03 OFF   -oo -100 POST
+/bus/13/mix/03 OFF   -oo -100 POST 0
 /bus/13/mix/04 OFF   -oo
-/bus/13/mix/05 ON   -oo -100 POST
+/bus/13/mix/05 ON   -oo -100 POST 0
 /bus/13/mix/06 ON   -oo
 /bus/13/grp %00000000 %000000
 /bus/14/config "ACU REV" 1 MG
@@ -1705,13 +1711,13 @@
 /bus/14/eq/5 PEQ 5k02 +0.00 2.0
 /bus/14/eq/6 HShv 10k02 +0.00 2.0
 /bus/14/mix ON   0.0 OFF +0 OFF   -oo
-/bus/14/mix/01 OFF   -oo +0 POST
+/bus/14/mix/01 OFF   -oo +0 POST 0
 /bus/14/mix/02 OFF   -oo
-/bus/14/mix/03 OFF   -oo +0 POST
+/bus/14/mix/03 OFF   -oo +0 POST 0
 /bus/14/mix/04 OFF   -oo
-/bus/14/mix/05 OFF   -oo +100 POST
+/bus/14/mix/05 OFF   -oo +100 POST 0
 /bus/14/mix/06 OFF   -oo
-/bus/14/grp %00000000 %000000
+/bus/14/grp %00100000 %000000
 /bus/15/config "VOX REV" 1 MG
 /bus/15/dyn OFF COMP RMS LOG 0.0 3.0 1 0.00 10 10.0  151 POST 0 100 OFF
 /bus/15/dyn/filter OFF 3.0 990.9
@@ -1724,13 +1730,13 @@
 /bus/15/eq/5 PEQ 5k02 +0.00 2.0
 /bus/15/eq/6 HShv 10k02 +0.00 2.0
 /bus/15/mix ON   0.0 OFF +0 OFF   -oo
-/bus/15/mix/01 OFF   -oo +0 POST
+/bus/15/mix/01 OFF   -oo +0 POST 0
 /bus/15/mix/02 OFF   -oo
-/bus/15/mix/03 OFF   -oo +0 POST
+/bus/15/mix/03 OFF   -oo +0 POST 0
 /bus/15/mix/04 OFF   -oo
-/bus/15/mix/05 ON   -oo +0 POST
+/bus/15/mix/05 ON   -oo +0 POST 0
 /bus/15/mix/06 ON   -oo
-/bus/15/grp %00000000 %000000
+/bus/15/grp %00100000 %000000
 /bus/16/config "VOX DELAY" 1 MG
 /bus/16/dyn OFF COMP RMS LOG 0.0 3.0 1 0.00 10 10.0  151 POST 0 100 OFF
 /bus/16/dyn/filter OFF 3.0 990.9
@@ -1742,14 +1748,14 @@
 /bus/16/eq/4 PEQ 1k97 +0.00 2.0
 /bus/16/eq/5 PEQ 5k02 +0.00 2.0
 /bus/16/eq/6 HShv 10k02 +0.00 2.0
-/bus/16/mix ON   0.0 OFF +0 OFF   -oo
-/bus/16/mix/01 OFF   -oo +0 POST
+/bus/16/mix ON -20.0 OFF +0 OFF   -oo
+/bus/16/mix/01 OFF   -oo +0 POST 0
 /bus/16/mix/02 OFF   -oo
-/bus/16/mix/03 OFF   -oo +0 POST
+/bus/16/mix/03 OFF   -oo +0 POST 0
 /bus/16/mix/04 OFF   -oo
-/bus/16/mix/05 ON   -oo +0 POST
+/bus/16/mix/05 ON   -oo +0 POST 0
 /bus/16/mix/06 ON   -oo
-/bus/16/grp %00000000 %000000
+/bus/16/grp %00100000 %000000
 /mtx/01/config "X6" 1 WHi
 /mtx/01/preamp OFF
 /mtx/01/dyn OFF COMP RMS LOG 0.0 3.0 1 0.00 10 10.0  151 POST 100 OFF
@@ -1763,6 +1769,7 @@
 /mtx/01/eq/5 PEQ 5k02 +0.00 2.0
 /mtx/01/eq/6 HShv 10k02 +0.00 2.0
 /mtx/01/mix ON  -1.3
+/mtx/01/grp %00000000 %000000
 /mtx/02/config "X4" 1 WHi
 /mtx/02/preamp OFF
 /mtx/02/dyn OFF COMP RMS LOG 0.0 3.0 1 0.00 10 10.0  151 POST 100 OFF
@@ -1776,6 +1783,7 @@
 /mtx/02/eq/5 PEQ 5k02 +0.00 2.0
 /mtx/02/eq/6 HShv 10k02 +0.00 2.0
 /mtx/02/mix ON  -1.5
+/mtx/02/grp %00000000 %000000
 /mtx/03/config "i5" 1 WHi
 /mtx/03/preamp OFF
 /mtx/03/dyn OFF COMP RMS LOG 0.0 3.0 1 0.00 10 10.0  151 POST 100 OFF
@@ -1789,6 +1797,7 @@
 /mtx/03/eq/5 PEQ 5k02 +0.00 2.0
 /mtx/03/eq/6 HShv 20k00 +0.00 2.0
 /mtx/03/mix ON  -9.0
+/mtx/03/grp %00000000 %000000
 /mtx/04/config "" 1 OFF
 /mtx/04/preamp OFF
 /mtx/04/dyn OFF COMP RMS LOG 0.0 3.0 1 0.00 10 10.0  151 POST 100 OFF
@@ -1802,6 +1811,7 @@
 /mtx/04/eq/5 PEQ 5k02 +0.00 2.0
 /mtx/04/eq/6 HShv 20k00 +0.00 2.0
 /mtx/04/mix ON   -oo
+/mtx/04/grp %00000000 %000000
 /mtx/05/config "STREAM L" 1 WHi
 /mtx/05/preamp OFF
 /mtx/05/dyn ON COMP PEAK LOG -6.0 5.0 2 0.00 6 10.0  198 POST 100 OFF
@@ -1815,6 +1825,7 @@
 /mtx/05/eq/5 PEQ 5k02 +0.00 2.0
 /mtx/05/eq/6 HShv 10k02 +0.00 2.0
 /mtx/05/mix ON  -9.2
+/mtx/05/grp %00000000 %000000
 /mtx/06/config "STREAM R" 1 WHi
 /mtx/06/preamp OFF
 /mtx/06/dyn ON COMP PEAK LOG -6.0 5.0 2 0.00 6 10.0  198 POST 100 OFF
@@ -1828,6 +1839,7 @@
 /mtx/06/eq/5 PEQ 5k02 +0.00 2.0
 /mtx/06/eq/6 HShv 10k02 +0.00 2.0
 /mtx/06/mix ON  -9.2
+/mtx/06/grp %00000000 %000000
 /main/st/config "" 66 WH
 /main/st/dyn ON COMP RMS LOG -12.5 7.0 5 2.00 10 10.0  151 POST 100 ON
 /main/st/dyn/filter OFF 3.0 990.9
@@ -1840,12 +1852,13 @@
 /main/st/eq/5 PEQ 5k02 +0.00 2.0
 /main/st/eq/6 HShv 10k02 +0.00 2.0
 /main/st/mix ON  -4.4 +0
-/main/st/mix/01 ON   0.0 +0 POST
+/main/st/mix/01 ON   0.0 +0 POST 0
 /main/st/mix/02 ON   0.0
-/main/st/mix/03 ON   0.0 +0 POST
+/main/st/mix/03 ON   0.0 +0 POST 0
 /main/st/mix/04 ON   -oo
-/main/st/mix/05 ON   -oo +0 POST
+/main/st/mix/05 ON   -oo +0 POST 0
 /main/st/mix/06 ON   -oo
+/main/st/grp %00000000 %000000
 /main/m/config "SUB" 1 WHi
 /main/m/dyn OFF COMP RMS LOG 0.0 3.0 1 0.00 10 10.0  151 POST 100 OFF
 /main/m/dyn/filter OFF 3.0 990.9
@@ -1857,13 +1870,14 @@
 /main/m/eq/4 PEQ 1k97 +0.00 2.0
 /main/m/eq/5 PEQ 5k02 +0.00 2.0
 /main/m/eq/6 HCut 120.5 +0.00 2.0
-/main/m/mix ON -12.9
-/main/m/mix/01 OFF   -oo +0 POST
+/main/m/mix ON  -9.0
+/main/m/mix/01 OFF   -oo +0 POST 0
 /main/m/mix/02 OFF   -oo
-/main/m/mix/03 OFF   -oo +0 POST
+/main/m/mix/03 OFF   -oo +0 POST 0
 /main/m/mix/04 OFF   -oo
-/main/m/mix/05 ON   -oo +0 POST
+/main/m/mix/05 ON   -oo +0 POST 0
 /main/m/mix/06 ON   -oo
+/main/m/grp %00000000 %000000
 /dca/1 ON   -oo
 /dca/1/config "Drums" 1 RD
 /dca/2 ON   -oo
@@ -1895,7 +1909,7 @@
 /fx/5 DES2
 /fx/5/par 13.0 12.0 18.0 8.0 FEM MALE 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 /fx/6 ULC
-/fx/6/par ON -10 -21 1.0 1.7 ALL 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+/fx/6/par ON -16 -21 1.0 1.7 ALL 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 /fx/7 GEQ2
 /fx/7/par 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0 0.5 -0.5 -1.0 -1.0 -5.0 -5.5 -6.0 -2.0 0.5 -1.5 -2.0 1.0 0.5 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
 /fx/8 TEQ

--- a/scenes/MosaikHeer-Update-14-11-2021.scn
+++ b/scenes/MosaikHeer-Update-14-11-2021.scn
@@ -18,7 +18,7 @@
 /config/routing/IN A1-8 A9-16 A17-24 A25-32 AUX1-4
 /config/routing/AES50A OUT1-8 OUT9-16 OUT1-8 OUT1-8 OUT1-8 OUT1-8
 /config/routing/AES50B OUT9-16 OUT9-16 OUT9-16 OUT9-16 OUT9-16 OUT9-16
-/config/routing/CARD A1-8 A9-16 A17-24 A25-32
+/config/routing/CARD OUT1-8 OUT9-16 P161-8 A25-32
 /config/routing/OUT OUT1-4 AUX/CR OUT9-12 OUT13-16
 /config/routing/PLAY AN1-8 AN1-8 AN1-8 AN1-8 AUX1-4
 /config/userctrl/A WH


### PR DESCRIPTION
- changed default IEM Mix for all instruments: Click and MD Mics are in the mix per default, set own instrument to 0dB (for drums, bass and keys), changed OH send to livestream to pre-fader so drums can be properly heard in live stream
- removed FX from IEM mixes except for guitar (guitar reverb left in) and vocals (vocal reverb and delay left in)
- adjusted EQ for MD Mics (High- and Low-Cut) to remove bleed from cymbals and keep IEM mix clearer
- added Drum Bus for extrem compression (Bus 13)
- changed FX DCA to control the FX sends (instead of FX returns) so FX can fade out when setting DCA to 0dB
- slightly adjusted/unified FX sends of Vocals 
- slightly increased Sub level
- adjusted routing for IEM, Stream and Main Out recording