### PR TITLE
Correct PAN to +100 (100% R) on AUX 6 (Bkg Music R)

### DIFF
--- a/scenes/MosaikHeer.scn
+++ b/scenes/MosaikHeer.scn
@@ -1186,7 +1186,7 @@
 /auxin/06/eq/2 PEQ 496.6 +0.00 2.0
 /auxin/06/eq/3 PEQ 1k97 +0.00 2.0
 /auxin/06/eq/4 HShv 10k02 +0.00 2.0
-/auxin/06/mix ON  -5.0 ON -100 ON -10.0
+/auxin/06/mix ON  -5.0 ON +100 ON -10.0
 /auxin/06/mix/01 ON -21.0 +100 POST
 /auxin/06/mix/02 ON -21.0
 /auxin/06/mix/03 ON -21.0 +100 POST


### PR DESCRIPTION
Today the PAN on AUX 6 (Bkg Music R) was at -100 (full left)
Hence, there were no music coming out the right speaker.
Since the mixing table is on the left, it was only noticeable by
looking at the meter.

Note that was edited manually since using a M32 Edit for linux
result in a lot of changes.