### PR TITLE
Adding compressor to first 2 vocal mics

### DIFF
--- a/scenes/MosaikHeer.scn
+++ b/scenes/MosaikHeer.scn
@@ -555,7 +555,7 @@
 /ch/17/gate/filter OFF 3.0 990.9
 /ch/17/dyn ON COMP PEAK LOG -20.5 3.0 4 3.50 22 0.02  37 POST 0 100 OFF
 /ch/17/dyn/filter ON 2.0 1k97
-/ch/17/insert OFF POST FX5L
+/ch/17/insert ON POST FX5L
 /ch/17/eq ON
 /ch/17/eq/1 PEQ 148.3 -7.25 6.4
 /ch/17/eq/2 PEQ 363.9 -11.2 2.0
@@ -587,7 +587,7 @@
 /ch/18/gate/filter OFF 3.0 990.9
 /ch/18/dyn ON COMP PEAK LOG -18.5 3.0 4 2.00 10 0.02  40 POST 0 100 OFF
 /ch/18/dyn/filter ON 1.0 1k97
-/ch/18/insert OFF POST FX5R
+/ch/18/insert ON POST FX5R
 /ch/18/eq ON
 /ch/18/eq/1 PEQ 124.7 +0.00 2.0
 /ch/18/eq/2 PEQ 463.5 -9.75 2.0
@@ -1907,7 +1907,7 @@
 /fx/4/source INS INS
 /fx/4/par ON OFF 100 5 181 ON 2 ON 0 48 3 -13.0 1.5 0.0 0.0 0 0.0 0.0 0 0.0 0.0 0 0.0 0.0 0 0.0 0.0 0 GR 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 /fx/5 LEC2
-/fx/5/par ON 40 30 COMP 0.0 ON 40 30 COMP 0.0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+/fx/5/par ON 62 58 COMP 0.0 ON 40 36 COMP 0.0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 /fx/6 ULC2
 /fx/6/par ON -19 -23 3.0 1.9 ALL ON -31 -21 3.0 5.0 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 /fx/7 GEQ2

--- a/scenes/MosaikHeer.scn
+++ b/scenes/MosaikHeer.scn
@@ -2,7 +2,7 @@
 /config/chlink OFF OFF ON OFF OFF ON ON OFF OFF OFF OFF OFF ON OFF ON OFF
 /config/auxlink OFF OFF ON ON
 /config/fxlink ON ON ON ON
-/config/buslink ON ON ON ON OFF ON OFF OFF
+/config/buslink ON ON ON OFF OFF ON OFF OFF
 /config/mtxlink OFF OFF ON
 /config/mute OFF OFF OFF OFF OFF OFF
 /config/linkcfg ON ON ON ON
@@ -1490,7 +1490,7 @@
 /bus/02/mix/05 OFF   -oo +100 POST 0
 /bus/02/mix/06 OFF   -oo
 /bus/02/grp %00000000 %000000
-/bus/03/config "Bass L" 1 CY
+/bus/03/config "Guitar L" 1 CY
 /bus/03/dyn ON COMP RMS LOG -1.0 100 0 0.00 0 0.02  504 POST 0 100 OFF
 /bus/03/dyn/filter OFF 3.0 990.9
 /bus/03/insert OFF POST OFF
@@ -1509,7 +1509,7 @@
 /bus/03/mix/05 OFF   -oo -100 POST 0
 /bus/03/mix/06 OFF   -oo
 /bus/03/grp %00000000 %000000
-/bus/04/config "Bass R" 1 CY
+/bus/04/config "Guitar R" 1 CY
 /bus/04/dyn ON COMP RMS LOG -1.0 100 0 0.00 0 0.02  504 POST 0 100 OFF
 /bus/04/dyn/filter OFF 3.0 990.9
 /bus/04/insert OFF POST OFF
@@ -1528,7 +1528,7 @@
 /bus/04/mix/05 OFF   -oo +100 POST 0
 /bus/04/mix/06 OFF   -oo
 /bus/04/grp %00000000 %000000
-/bus/05/config "Git L" 1 CY
+/bus/05/config "Keys L" 1 CY
 /bus/05/dyn ON COMP RMS LOG -1.0 100 0 0.00 0 0.02  504 POST 0 100 OFF
 /bus/05/dyn/filter OFF 3.0 990.9
 /bus/05/insert OFF POST OFF
@@ -1547,7 +1547,7 @@
 /bus/05/mix/05 ON   -oo -100 POST 0
 /bus/05/mix/06 ON   -oo
 /bus/05/grp %00000000 %000000
-/bus/06/config "Git R" 1 CY
+/bus/06/config "Keys R" 1 CY
 /bus/06/dyn ON COMP RMS LOG -1.0 100 0 0.00 0 0.02  504 POST 0 100 OFF
 /bus/06/dyn/filter OFF 3.0 990.9
 /bus/06/insert OFF POST OFF
@@ -1566,7 +1566,7 @@
 /bus/06/mix/05 ON   -oo +100 POST 0
 /bus/06/mix/06 ON   -oo
 /bus/06/grp %00000000 %000000
-/bus/07/config "Keys L" 1 CY
+/bus/07/config "Bass" 1 CY
 /bus/07/dyn ON COMP RMS LOG -1.0 100 0 0.00 0 0.02  504 POST 0 100 OFF
 /bus/07/dyn/filter OFF 3.0 990.9
 /bus/07/insert OFF POST OFF
@@ -1582,10 +1582,10 @@
 /bus/07/mix/02 OFF   -oo
 /bus/07/mix/03 OFF   -oo -100 POST 0
 /bus/07/mix/04 OFF   -oo
-/bus/07/mix/05 ON   -oo -100 POST 0
-/bus/07/mix/06 ON   -oo
+/bus/07/mix/05 OFF   -oo +0 POST 0
+/bus/07/mix/06 OFF   -oo
 /bus/07/grp %00000000 %000000
-/bus/08/config "Keys R" 1 CY
+/bus/08/config "Voc 1" 1 CY
 /bus/08/dyn ON COMP RMS LOG -1.0 100 0 0.00 0 0.02  504 POST 0 100 OFF
 /bus/08/dyn/filter OFF 3.0 990.9
 /bus/08/insert OFF POST OFF
@@ -1601,10 +1601,10 @@
 /bus/08/mix/02 OFF   -oo
 /bus/08/mix/03 OFF   -oo +100 POST 0
 /bus/08/mix/04 OFF   -oo
-/bus/08/mix/05 ON   -oo +100 POST 0
-/bus/08/mix/06 ON   -oo
+/bus/08/mix/05 OFF   -oo +0 POST 0
+/bus/08/mix/06 OFF   -oo
 /bus/08/grp %00000000 %000000
-/bus/09/config "Vox 1" 1 CY
+/bus/09/config "Voc 2" 1 CY
 /bus/09/dyn ON COMP RMS LOG -1.0 100 0 0.00 0 0.02  504 POST 0 100 OFF
 /bus/09/dyn/filter OFF 3.0 990.9
 /bus/09/insert OFF POST OFF
@@ -1623,7 +1623,7 @@
 /bus/09/mix/05 ON   -oo +0 POST 0
 /bus/09/mix/06 ON   -oo
 /bus/09/grp %00000000 %000000
-/bus/10/config "Vox 2" 1 CY
+/bus/10/config "Voc 3" 1 CY
 /bus/10/dyn ON COMP RMS LOG -1.0 100 0 0.00 0 0.02  504 POST 0 100 OFF
 /bus/10/dyn/filter OFF 3.0 990.9
 /bus/10/insert OFF POST OFF


### PR DESCRIPTION
The compressor for the vocal mics have been configured but the insert on the channels Voc 1 and Voc 2 were not switched on. This has been fixed now. We are using the Dual Leisure Compressor for these vocal mics.